### PR TITLE
Fapi: Fix consistency of tss2_* tools

### DIFF
--- a/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
@@ -8,14 +8,18 @@ _tss2_authorizepolicy()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pkr] | --policyPath | --keyPath  | --policyRef)
+        -!(-*)[r] | --policyRef)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[Pp] | --policyPath | --keyPath )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath= -p
-      --keyPath=  -k --policyRef=  -r" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath -P
+      --keyPath -p --policyRef -r" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_authorizepolicy tss2_authorizepolicy

--- a/dist/bash-completion/tpm2-tools/tss2_changeauth
+++ b/dist/bash-completion/tpm2-tools/tss2_changeauth
@@ -8,14 +8,14 @@ _tss2_changeauth()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ae] | --authValue | --entityPath)
+        -!(-*)[ap] | --authValue | --entityPath)
             return;;
     esac
 
     $split && return
 
     COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -a --authValue
-    -e --entityPath=" -- "$cur") )
+    -p --entityPath" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_changeauth tss2_changeauth

--- a/dist/bash-completion/tpm2-tools/tss2_createkey
+++ b/dist/bash-completion/tpm2-tools/tss2_createkey
@@ -8,14 +8,14 @@ _tss2_createkey()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ptla] | --path | --type | --policyPath | --authValue)
+        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=  -t --type=
-    -l --policyPath=  -a --authValue" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path  -t --type
+    -P --policyPath  -a --authValue" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createkey tss2_createkey

--- a/dist/bash-completion/tpm2-tools/tss2_createnv
+++ b/dist/bash-completion/tpm2-tools/tss2_createnv
@@ -8,17 +8,14 @@ _tss2_createnv()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)t | --type)
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)[psPa] | --path | --size |--policyPath | --authValue)
+        -!(-*)[stpPa] | --size | --type | --path | --policyPath | --authValue)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policy-path=
-    -p --path= -s --size= -t --type= -a --authValue" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policyPath
+    -p --path -s --size -t --type -a --authValue" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createnv tss2_createnv

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -8,13 +8,17 @@ _tss2_createseal()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ptPad] | --path | --type | --policyPath | --authValue | --data)
+        -!(-*)[i] | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --password -a --path= -p --policyPath= -P --type= -t --data= -d" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue -a --path -p --policyPath -P --type -t --data -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createseal tss2_createseal

--- a/dist/bash-completion/tpm2-tools/tss2_decrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_decrypt
@@ -8,15 +8,17 @@ _tss2_decrypt()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[kpc] | --keyPath | --plainText | --cipherText)
+        -!(-*)[io] | --cipherText | --plainText)
             _filedir
             COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --keyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -c --cipherText= --plainText= -p --keyPath= -k" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -i --cipherText --plainText -o --keyPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_decrypt tss2_decrypt

--- a/dist/bash-completion/tpm2-tools/tss2_delete
+++ b/dist/bash-completion/tpm2-tools/tss2_delete
@@ -9,13 +9,12 @@ _tss2_delete()
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
         -!(-*)p | --path)
-            COMPREPLY=( $(compgen -W "$(tss2_list --path=$cur)" -- $cur))
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_delete tss2_delete

--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -8,18 +8,18 @@ _tss2_encrypt()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[cP] | --cipherText | --plainText)
+        -!(-*)[io] | --plainText | --cipherText)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[kp] | --keyPath | --policyPath)
+        -!(-*)[pP] | --keyPath | --policyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --cipherText= -c
-    --keyPath= k --policyPath= -p --plainText= -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -o --cipherText
+    -p --keyPath  -P --policyPath -i --plainText" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_encrypt tss2_encrypt

--- a/dist/bash-completion/tpm2-tools/tss2_exportkey
+++ b/dist/bash-completion/tpm2-tools/tss2_exportkey
@@ -8,17 +8,17 @@ _tss2_exportkey()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)e | --exportedData)
+        -!(-*)[o] | --exportedData )
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[pP] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
+        -!(-*)[pe] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData= -e --force -f --pathOfKeyToDuplicate= -p --pathToPublicKeyOfNewParent= -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData -o --force -f --pathOfKeyToDuplicate -p --pathToPublicKeyOfNewParent -e" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_exportkey tss2_exportkey

--- a/dist/bash-completion/tpm2-tools/tss2_exportpolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_exportpolicy
@@ -8,18 +8,18 @@ _tss2_exportpolicy()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)j | --jsonPolicy)
+        -!(-*)[o] | --jsonPolicy )
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)p | --path)
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy= -j
-    --path= -p --force= -f" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy -o
+    --path -p --force -f" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_exportpolicy tss2_exportpolicy

--- a/dist/bash-completion/tpm2-tools/tss2_getappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_getappdata
@@ -8,17 +8,17 @@ _tss2_getappdata()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)a | --appData)
+        -!(-*)[o] | --appData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)p | --path)
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -a" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getappdata tss2_getappdata

--- a/dist/bash-completion/tpm2-tools/tss2_getcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_getcertificate
@@ -8,17 +8,17 @@ _tss2_getcertificate()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)x | --x509certData)
+        -!(-*)[o] | --x509certData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)p | --path)
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --x509certData= -x" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --x509certData -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getcertificate tss2_getcertificate

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -8,14 +8,18 @@ _tss2_getdescription()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pd] | --path | --description)
+        -!(-*)[o] | --description)
+            COMPREPLY+=( '-' )
+            _filedir
+            return;;
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p
-    --description= -d " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p
+    --description -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getdescription tss2_getdescription

--- a/dist/bash-completion/tpm2-tools/tss2_getinfo
+++ b/dist/bash-completion/tpm2-tools/tss2_getinfo
@@ -8,7 +8,7 @@ _tss2_getinfo()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)i | --info)
+        -!(-*)o | --info)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -16,7 +16,7 @@ _tss2_getinfo()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info= -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getinfo tss2_getinfo

--- a/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
+++ b/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
@@ -8,7 +8,7 @@ _tss2_getplatformcertificates()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)c | --certificates)
+        -!(-*)o | --certificates)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -16,7 +16,7 @@ _tss2_getplatformcertificates()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates= -c" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getplatformcertificates tss2_getplatformcertificates

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -8,7 +8,7 @@ _tss2_getrandom()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)o | --data)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_getrandom()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes= --data= -d -n" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes -n --data -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getrandom tss2_getrandom

--- a/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
@@ -8,19 +8,9 @@ _tss2_gettpmblobs()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)p | --path)
-            _filedir
-            COMPREPLY+=( '-' )
+        -!(-*)[p] | --path )
             return;;
-        -!(-*)u | --tpm2bPublic
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)r | --tpm2bPrivate
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)l | --policy
+        -!(-*)[url] | --tpm2bPublic | --tpm2bPrivate | --policy)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -28,7 +18,7 @@ _tss2_gettpmblobs()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path= -p --tpm2bPublic= -u --tpm2bPrivate= -r --policy= -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path -p --tpm2bPublic -u --tpm2bPrivate -r --policy -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_gettpmblobs tss2_gettpmblobs

--- a/dist/bash-completion/tpm2-tools/tss2_import
+++ b/dist/bash-completion/tpm2-tools/tss2_import
@@ -8,17 +8,17 @@ _tss2_import()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --importData)
+        -!(-*)[p] | --path)
+            return;;
+        -!(-*)[i] | --importData)
             _filedir
             COMPREPLY+=( '-' )
-            return;;
-        -!(-*)p | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --importData= -d --path= -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --importData -i --path -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_import tss2_import

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -8,14 +8,18 @@ _tss2_list()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ps] | --pathList | searchPath )
+        -!(-*)[p] | --searchPath)
+            return;;
+        -!(-*)[o] | --pathList)
+            _filedir
+            COMPREPLY+=( '-' )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -p
-    --searchPath -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -o
+    --searchPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_list tss2_list

--- a/dist/bash-completion/tpm2-tools/tss2_nvextend
+++ b/dist/bash-completion/tpm2-tools/tss2_nvextend
@@ -8,17 +8,17 @@ _tss2_nvextend()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)[il] | --data |  --logData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[nl] | --nvPath | --logData)
+        -!(-*)[p] | --nvPath )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --policy-path= --data= --nvPath= --logData= -d -n -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -i --nvPath -p --logData -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvextend tss2_nvextend

--- a/dist/bash-completion/tpm2-tools/tss2_nvincrement
+++ b/dist/bash-completion/tpm2-tools/tss2_nvincrement
@@ -8,13 +8,13 @@ _tss2_nvincrement()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)n | --nvPath)
+        -!(-*)p | --nvPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -n" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvincrement tss2_nvincrement

--- a/dist/bash-completion/tpm2-tools/tss2_nvread
+++ b/dist/bash-completion/tpm2-tools/tss2_nvread
@@ -8,17 +8,17 @@ _tss2_nvread()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)[p] | --nvPath)
+            return;;
+        -!(-*)[ol] | --data | --logData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[nl] | --nvPath | --logData)
-            return
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath= -n --data= -d --logData= -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath -p --data -o --logData -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvread tss2_nvread

--- a/dist/bash-completion/tpm2-tools/tss2_nvsetbits
+++ b/dist/bash-completion/tpm2-tools/tss2_nvsetbits
@@ -8,13 +8,13 @@ _tss2_nvsetbits()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[bn] | --bitmap | --nvPath)
+        -!(-*)[ip] | --bitmap | --nvPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -b --bitmap= --nvPath= -n" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -i --bitmap -p --nvPath" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvsetbits tss2_nvsetbits

--- a/dist/bash-completion/tpm2-tools/tss2_nvwrite
+++ b/dist/bash-completion/tpm2-tools/tss2_nvwrite
@@ -8,17 +8,17 @@ _tss2_nvwrite()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)[p] | --nvPath)
+            return;;
+        -!(-*)[i] | --data)
             _filedir
             COMPREPLY+=( '-' )
-            return;;
-        -!(-*)[n] | --nvPath )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= --data= -n -d" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p --data  -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvwrite tss2_nvwrite

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -8,13 +8,17 @@ _tss2_pcrextend()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[cdl] | --pcr | --data | --logData)
+        -!(-*)[x] | --pcr)
+            return;;
+        -!(-*)[il] | --data | --logData)
+            _filedir
+            COMPREPLY+=( '-' )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -c -d --pcr --data --logData -l -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr -i --data -l --logData -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrextend tss2_pcrextend

--- a/dist/bash-completion/tpm2-tools/tss2_pcrread
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrread
@@ -8,9 +8,9 @@ _tss2_pcrread()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)i | --pcrIndex)
+        -!(-*)[x] | --pcrIndex)
             return;;
-        -!(-*)[cl] | --pcrValue | --pcrLog)
+        -!(-*)[ol] | --pcrValue | --pcrLog)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_pcrread()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrValue= --pcrIndex= --force -f --pcrLog= -c -i -f -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -o --pcrValue -x --pcrIndex --force -f -l --pcrLog" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrread tss2_pcrread

--- a/dist/bash-completion/tpm2-tools/tss2_provision
+++ b/dist/bash-completion/tpm2-tools/tss2_provision
@@ -8,13 +8,13 @@ _tss2_provision()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[esl] | --authValueEh | --authValueSh | --authValueLockout )
+        -!(-*)[ESL] | --authValueEh | --authValueSh | --authValueLockout )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -e -s -l --authValueEh --authValueSh --authValueLockout" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -E -S -L --authValueEh --authValueSh --authValueLockout" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_provision tss2_provision

--- a/dist/bash-completion/tpm2-tools/tss2_quote
+++ b/dist/bash-completion/tpm2-tools/tss2_quote
@@ -8,17 +8,17 @@ _tss2_quote()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[slqdc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
+        -!(-*)[px] | --keyPath | --pcrList)
+            return;;
+        -!(-*)[olqQc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
             _filedir
             COMPREPLY+=( '-' )
-            return;;
-        -!(-*)[Lk] | --pcrList | --keyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -L -l -d -s -f -k -d -q -c --pcrList= --qualifyingData= --pcrLog= --force --path= --quoteInfo= --signature= --certificate= " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrList -x --qualifyingData -Q --pcrLog -l --force -f --keyPath -p --quoteInfo -q --signature -o --certificate -c " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_quote tss2_quote

--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -8,17 +8,13 @@ _tss2_setappdata()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)a | --appData)
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)p | --path)
+        -!(-*)[pi] | --path | --appData)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -a" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -i" -- "$cur") )
 
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_setcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_setcertificate
@@ -8,7 +8,7 @@ _tss2_setcertificate()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)x | --x509certData)
+        -!(-*)i | --x509certData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_setcertificate()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path= --x509certData= -x" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path --x509certData -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_setcertificate tss2_setcertificate

--- a/dist/bash-completion/tpm2-tools/tss2_setdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_setdescription
@@ -8,13 +8,13 @@ _tss2_setdescription()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pd] | --path | --description)
+        -!(-*)[pi] | --path | --description)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p --description -d " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p --description -i " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_setdescription tss2_setdescription

--- a/dist/bash-completion/tpm2-tools/tss2_sign
+++ b/dist/bash-completion/tpm2-tools/tss2_sign
@@ -8,17 +8,17 @@ _tss2_sign()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[dspcP] | --digest | --signature | --publicKey | --certificate | --padding)
+        -!(-*)[dokc] | --digest | --signature | --publicKey | --certificate)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)k | --keyPath)
+        -!(-*)[ps] | --keyPath | --padding)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate= -c --digest= -d --keyPath= -k --publicKey= -p --signature= -s --padding -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate -c --digest -d --keyPath -p --publicKey -k --signature -o --padding -s" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_sign tss2_sign

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -8,7 +8,7 @@ _tss2_unseal()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)o | --data)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_unseal()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --data= -d --path= -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -o --path -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_unseal tss2_unseal

--- a/dist/bash-completion/tpm2-tools/tss2_verifyquote
+++ b/dist/bash-completion/tpm2-tools/tss2_verifyquote
@@ -8,17 +8,17 @@ _tss2_verifyquote()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[qs] | --qualifyingData | --signature)
+        -!(-*)[Qilq] | --qualifyingData | --signature | --pcrLog | --quoteInfo)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[lip] | --pcrLog | --quoteInfo | --publicKeyPath)
+        -!(-*)[k] | --publicKeyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData= -q --pcrLog= -l --quoteInfo= -i --publicKeyPath= -p --signature= -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData -Q --pcrLog -l --quoteInfo -q --publicKeyPath -k --signature -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_verifyquote tss2_verifyquote

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -8,17 +8,17 @@ _tss2_verifysignature()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ds] | --digest | --signature)
+        -!(-*)[di] | --digest | --signature)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)k | --keyPath)
+        -!(-*)p | --keyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --digest= -d --keyPath= -k --signature= -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --digest -d --keyPath -p --signature -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2verify_signature tss2verify_signature

--- a/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
+++ b/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
@@ -8,19 +8,13 @@ _tss2_writeauthorizenv()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)n | --nvPath)
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)l | --policyPath )
-            _filedir
-            COMPREPLY+=( '-' )
+        -!(-*)[pP] | --nvPath | --policyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -n -policyPath= -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p -policyPath -P" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_writeauthorizenv tss2_writeauthorizenv

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-p**, **\--policyPath**:
+  * **-P**, **\--policyPath**:
     Path of the new policy. MUST NOT be NULL.
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
     Path of the signing key. MUST NOT be NULL.
 
-  * **-r**, **\--policyRef**=:
+  * **-r**, **\--policyRef**:
     A byte buffer to be included in the signature. MAY be NULL if policyRefSize is 0.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -24,7 +24,7 @@ These are the available options:
 
     The new 0-terminated password. MAY be NULL. If NULL then the password is set to the empty string.
 
-  * **-e**, **\--entityPath**=:
+  * **-p**, **\--entityPath**:
 
     The path identifying the entity to modify. MUST NOT be NULL.
 
@@ -34,7 +34,7 @@ These are the available options:
 
 ## Change a password for an entity HS/SRK/myRSACryptKey to M1
 ```
-tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue=M1
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue M1
 ```
 
 ## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password with disabled ecoh.

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path to the new key. MUST NOT be NULL.
 
@@ -26,7 +26,7 @@ These are the available options:
 
     Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
 
-  * **-l**, **\--policyPath**:
+  * **-P**, **\--policyPath**:
 
     The policy to be associated with the new key. policyPath MAY be NULL. If NULL then no policy will be associated with the key.
 
@@ -50,7 +50,7 @@ tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue
 
 ## Create a key with password “abc”.
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue=abc
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue abc
 ```
 
 # RETURNS

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     Path of the new NV space. MUST NOT be NULL.
 
@@ -30,13 +30,13 @@ These are the available options:
 
     The size in bytes of the NV index to be created. MAY be zero if the size is inferred from the type; e.g. an NV index of type counter has a size of 8 bytes.
 
-  * **-P**, **\--policy-path**:
+  * **-P**, **\--policyPath**:
 
     Identifies the policy to be associated with the new NV space. MAY be NULL. If NULL then no policy will be associated with the NV space.
 
   * **-a**, **\--authValue**:
 
-    The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string
+    The new authorization value for the nv index. MAY be NULL. If NULL then the authorization value will be the empty string
 
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path to the new key. MUST NOT be NULL.
 
@@ -34,7 +34,7 @@ These are the available options:
 
     The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string.
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     the data to be sealed by the TPM. MAY be NULL.
 
@@ -44,7 +44,7 @@ These are the available options:
 
 ## Create a key without password and read data to be sealed from file.
 ```
-tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue=abc --data abc
+tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data abc
 ```
 
 # RETURNS

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     Identifies the decryption key. MUST NOT be NULL.
 
-  * **-c**, **\--cipherText**: \<filename\>
+  * **-i**, **\--cipherText**: \<filename\>
 
     The JSON-encoded cipherText. MUST NOT be NULL.
 
@@ -30,7 +30,7 @@ These are the available options:
 
     Force Overwriting the output file.
 
-  * **-p**, **\--plainText**: \<filename\>
+  * **-o**, **\--plainText**: \<filename\>
 
     Returns the decrypted data. MAY be NULL.
 
@@ -38,7 +38,7 @@ These are the available options:
 
 # EXAMPLE
 
-    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText=encrypted.file --plainText=-
+    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText encrypted.file --plainText abc
 
 # RETURNS
 

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -27,7 +27,7 @@ actions SHALL be taken:
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path to the entity to delete. MUST NOT be NULL.
 
@@ -37,7 +37,7 @@ These are the available options:
 
 # Deletes storage hierarchy (HS) and everything below it:
 ```
-tss2_delete --path=HS
+tss2_delete --path /HS
 ```
 
 # RETURNS

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -27,7 +27,7 @@ If encrypting for a remote TPM, an asymmetric storage key is required as keyPath
 
 These are the available options:
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     Identifies the encryption key. MUST NOT be NULL.
 
@@ -35,15 +35,15 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--policyPath**:
+  * **-P**, **\--policyPath**:
 
     Identifies the policy to be associated with the sealed data. MAY be NULL. If NULL then the sealed data will have no policy.
 
-  * **-P**, **\--plainText**:
+  * **-i**, **\--plainText**:
 
     The data to be encrypted. MUST NOT be NULL.
 
-  * **-c**, **\--cipherText**:
+  * **-o**, **\--cipherText**:
 
     Returns the JSON-encoded ciphertext. MUST NOT be NULL.
 

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-P** **\--pathToPublicKeyOfNewParent**:
+  * **-e** **\--pathToPublicKeyOfNewParent**:
 
     The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext. If NULL only the public key will exported.
 
@@ -26,7 +26,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-e**, **\--exportedData**:
+  * **-o**, **\--exportedData**:
 
     Returns the exported subtree. MUST NOT be NULL.
 

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -12,7 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_policyexport**(1) - This commands exports a policy referred to by a path in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
+**tss2_policyexport**(1) - This commands exports a policy associated with a key
+in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
 
 # OPTIONS
 
@@ -22,13 +23,13 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-j**, **\--jsonPolicy**:
+  * **-o**, **\--jsonPolicy**:
 
     Returns the JSON-encoded policy. MUST NOT be NULL.
 
   * **-p**, **\--path**:
 
-    The path of the new policy. MUST NOT be NULL.
+    The path of the key. MUST NOT be NULL.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Path of the object for which the appData will be loaded. MUST NOT be NULL.
 
-  * **-a**, **\--appData**:
+  * **-o**, **\--appData**:
 
     Returns a copy of the stored data. MAY be NULL.
 

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The entity whose certificate is requested. MUST NOT be NULL.
 
-  * **-x**, **\--x509certData**:
+  * **-o**, **\--x509certData**:
 
     Returns the PEM encoded certificate. MUST NOT be NULL. If no certificate is stored, then an empty string is returned.
 

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -18,11 +18,15 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
 
     The path of the object for which the appData will be loaded. MUST NOT be NULL.
 
-  * **-d**, **\--description**=:
+  * **-o**, **\--description**:
 
     Returns the stored description. MUST NOT be NULL.
 

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-i**, **\--info**:
+  * **-o**, **\--info**:
 
     Returns the FAPI and TPM information. MUST NOT be NULL.
 

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_getplatformcertificates**(1) - This command returns the set of Platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.
+**tss2_getplatformcertificates**(1) - This command returns the set of platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.
 
 # OPTIONS
 
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-c**, **\--certificates**:
+  * **-o**, **\--certificates**:
 
     Returns a continuous buffer containing the concatenated platform certificates. MUST NOT be NULL.
 

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -26,7 +26,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-d**, **\--data**: \<filename\>
+  * **-o**, **\--data**: \<filename\>
 
     The returned random bytes. MUST NOT be NULL.
 

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -42,7 +42,7 @@ These are the available options:
 
 # EXAMPLE
 
-tss2_gettpmblobs --path=HS/SRK/myRSACrypt --tpm2bPublic=public.file --tpm2bPrivate=private.file --policy=policy.file
+tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic public.file --tpm2bPrivate private.file --policy policy.file
 
 # RETURNS
 

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path of the new object. MUST NOT be NULL.
 
-  * **-d**, **\--importData=**:
+  * **-i**, **\--importData**:
 
     The data to be imported. MUST NOT be NULL.
 

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-s**, **\--searchPath**:
+  * **-p**, **\--searchPath**:
 
     The path identifying the root of the search. MUST NOT be NULL.
 
-  * **-p**, **\--pathList**:
+  * **-o**, **\--pathList**:
 
     Returns the colon-separated list of paths. MUST NOT be NULL.
 
@@ -36,7 +36,7 @@ tss2_list
 ```
 ## List all entities under the HS path
 ```
-tss2_list --searchPath=HS --pathList output.file
+tss2_list --searchPath HS --pathList output.file
 ```
 
 # RETURNS

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     The data to be extended into the NV space. MUST NOT be NULL.
 
-  * **-n**, **\--nvPath**:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to write. MUST NOT be NULL.
 

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -18,7 +18,7 @@
 
 These are the availabe options:
 
-  * **-n**, **\--nvPath**=:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to increment. MUST NOT be NULL.
 

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -22,15 +22,15 @@ These are the availabe options:
 
     Force overwriting the output file.
 
-  * **-d**, **\--data**:
+  * **-o**, **\--data**:
 
     Returns the value read from the NV space. MUST NOT be NULL.
 
-  * **-n**, **\--nvPath**=:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to read. MUST NOT be NULL.
 
-  * **-l**, **\--logData**=:
+  * **-l**, **\--logData**:
 
     Returns the JSON encoded log, if the NV index is of type “extend” and an empty string otherwise. MAY be NULL.
 

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -18,11 +18,11 @@
 
 These are the availabe options:
 
-  * **-b**, **\--bitmap**==\<number\>:
+  * **-i**, **\--bitmap**:
 
     A mask indicating which bits to set in the NV space.
 
-  * **-n**, **\--nvPath**=:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to write. MUST NOT be NULL.
 

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     The data to write to the NV space. MUST NOT be NULL.
 
-  * **-n**, **\--nvPath**:
+  * **-p**, **\--nvPath**:
 
-    Identifies the NV space to write. MUST NOT be NULL.
+    Identifies the NV space to write to. MUST NOT be NULL.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -19,11 +19,11 @@ TPM2_PCR_Event.
 
 These are the available options:
 
-  * **-c**, **\--pcr**:
+  * **-x**, **\--pcr**:
 
    The PCR to extend.
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     The event data. Note that this data will be hashed using the respective PCR’s hash algorithm. See the TPM2_PCR_Event function of the TPM specification. MUST NOT be NULL.
 

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-c**, **\--pcrValue**:
+  * **-o**, **\--pcrValue**:
 
     Returns PCR digest. MAY be NULL.
 
-  * **-i**, **\--pcrIndex**:
+  * **-x**, **\--pcrIndex**:
 
     Identifies the PCR to read.
 

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -26,13 +26,13 @@ without authorization value is made persistent.
 
 These are the available options:
 
-  * **-e**, **\--authValueEh**=:
+  * **-E**, **\--authValueEh**:
     The authorization value for the privacy admin, i.e. the endorsement hierarchy. MAY be NULL.
 
-  * **-s**, **\--authValueSh**=:
+  * **-S**, **\--authValueSh**:
     The authorization value for the owner, i.e. the storage hierarchy. SHOULD be NULL.
 
-  * **-l**, **\--authValueLockout**=:
+  * **-L**, **\--authValueLockout**:
     The authorization value for the lockout authorization. SHOULD NOT be NULL.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-L**, **\--pcrList**:
+  * **-x**, **\--pcrList**:
 
     An array holding the PCR indices to quote against. MUST NOT be NULL.
 
-  * **-d**, **\--qualifyingData**:
+  * **-Q**, **\--qualifyingData**:
 
     A nonce provided by the caller to ensure freshness of the signature. MAY be
     NULL.
@@ -35,7 +35,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     Identifies the signing key. MUST NOT be NULL.
 
@@ -43,7 +43,7 @@ These are the available options:
 
     Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
 
-  * **-s**, **\--signature**:
+  * **-o**, **\--signature**:
 
     Returns the signature over the quoted material. MUST NOT be NULL.
 

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     Path of the object for which the appData will be stored. MUST NOT be NULL.
 
-  * **-a**, **\--appData**=:
+  * **-i**, **\--appData**:
 
     The data to be stored. MAY be NULL.
 

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     Identifies the entity to be associated with the certificate. MUST NOT be NULL.
 
-  * **-x**, **\--x509certData**:
+  * **-i**, **\--x509certData**:
 
     The PEM encoded certificate. MAY be NULL. If x509certData is NULL then the stored x509 certificate SHALL be removed.
 

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-d**, **\--description**:
+  * **-i**, **\--description**:
 
     The data to be stored as description for the object. MAY be NULL.
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path of the object for which the description will be stored. MUST NOT be NULL.
 

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     The path to the signing key. MUST NOT be NULL.
 
-  * **-P**, **\--padding**:
+  * **-s**, **\--padding**:
 
-    The padding algorithm used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
+    The padding scheme used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
 
   * **-c**, **\--certificate**:
 
@@ -38,11 +38,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--publicKey**:
+  * **-k**, **\--publicKey**:
 
     The public key associated with keyPath in PEM format. MAY be NULL.
 
-  * **-s**, **\--signature**:
+  * **-o**, **\--signature**:
 
     Returns the signature in binary form. MUST NOT be NULL.
 

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -26,7 +26,7 @@ These are the available options:
 
     Path of the object for which the blobs will be returned. MUST NOT be NULL.
 
-  * **-d**, **\--data**:
+  * **-o**, **\--data**:
 
     The decrypted data after unsealing. MAY be NULL.
 

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -26,7 +26,7 @@ An application using Fapi_VerifyQuote() will further have to
 
 These are the available options:
 
-  * **-q**, **\--qualifyingData**:
+  * **-Q**, **\--qualifyingData**:
 
     A nonce provided by the caller to ensure freshness of the signature. MAY be NULL.
 
@@ -34,15 +34,15 @@ These are the available options:
 
     Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
 
-  * **-i**, **\--quoteInfo**:
+  * **-q**, **\--quoteInfo**:
 
     The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
 
-  * **-p**, **\--publicKeyPath**=:
+  * **-k**, **\--publicKeyPath**:
 
     Identifies the signing key. MUST NOT be NULL. MAY be a path to the public key hierarchy /ext.
 
-  * **-s**, **\--signature**:
+  * **-i**, **\--signature**:
 
     The signature over the quoted material. MUST NOT be NULL.
 

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     The data that was signed, already hashed. MUST NOT be NULL
 
-  * **-k**, **\--keyPath**:
+  * **-p**, **\--keyPath**:
 
     Path to the verification public key. MUST NOT be NULL.
 
-  * **-s**, **\--signature**:
+  * **-i**, **\--signature**:
 
     The signature to be verified. MUST NOT be NULL.
 

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-n**, **\--nvPath**:
+  * **-p**, **\--nvPath**:
 
     The path of the NV index. MUST NOT be NULL.
 
-  * **-l**, **\--policyPath**=:
+  * **-P**, **\--policyPath**:
 
     The path of the new policy. MUST NOT be NULL.
 

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -60,7 +60,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     TSS2_RC r;
     uint8_t *policyRef = NULL;
     size_t policyRefSize = 0;
-    if(ctx.policyRef){
+    if (ctx.policyRef){
         r = open_read_and_close (ctx.policyRef, (void**)&policyRef,
             &policyRefSize);
         if (r){

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'p':
+    case 'P':
         ctx.policyPath = value;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
     case 'r':
@@ -34,11 +34,11 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"policyPath", required_argument, NULL, 'p'},
-        {"keyPath",    required_argument, NULL, 'k'},
+        {"policyPath", required_argument, NULL, 'P'},
+        {"keyPath",    required_argument, NULL, 'p'},
         {"policyRef",    required_argument, NULL, 'r'},
     };
-    return (*opts = tpm2_options_new ("p:k:r.", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("P:p:r.", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,12 +47,12 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.policyPath) {
         fprintf (stderr, "policy path to sign is missing, pass" \
-            "--policyPath=\n");
+            "--policyPath\n");
         return -1;
     }
     if (!ctx.keyPath) {
         fprintf (stderr, "key path for signing key is missing, pass" \
-            "--keyPath=\n");
+            "--keyPath\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -45,7 +45,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.entityPath) {
         fprintf (stderr, "No entity path provided, use --entityPath=\n");
-        if(ctx.authValue){
+        if (ctx.authValue){
             free (ctx.authValue);
         }
         return -1;
@@ -58,7 +58,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
 
-    if(ctx.authValue){
+    if (ctx.authValue){
         free (ctx.authValue);
     }
 

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -23,7 +23,7 @@ static bool on_option(char key, char *value) {
         if (!ctx.authValue)
             return false; /* User entered two different passwords */
         break;
-    case 'e':
+    case 'p':
         ctx.entityPath = value;
         break;
     }
@@ -34,9 +34,9 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"authValue", optional_argument, NULL, 'a'},
-        {"entityPath", required_argument, NULL, 'e'}
+        {"entityPath", required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("a:e:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("a:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -44,7 +44,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.entityPath) {
-        fprintf (stderr, "No entity path provided, use --entityPath=\n");
+        fprintf (stderr, "No entity path provided, use --entityPath\n");
         if (ctx.authValue){
             free (ctx.authValue);
         }

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -28,7 +28,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.keyPath = value;
         break;
-    case 'l':
+    case 'P':
         ctx.policyPath = value;
         break;
     case 't':
@@ -43,10 +43,10 @@ bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"       , required_argument, NULL, 'p'},
         {"type"       , required_argument, NULL, 't'},
-        {"policyPath", required_argument, NULL, 'l'},
+        {"policyPath", required_argument, NULL, 'P'},
         {"authValue"   , optional_argument, NULL, 'a'},
     };
-    return (*opts = tpm2_options_new ("a:p:l:t:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("a:p:P:t:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -54,12 +54,12 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "key path missing, use --path=\n");
+        fprintf (stderr, "key path missing, use --path\n");
         free (ctx.authValue);
         return -1;
     }
     if (!ctx.keyType) {
-        fprintf (stderr, "key type missing, use --type=\n");
+        fprintf (stderr, "key type missing, use --type\n");
         free (ctx.authValue);
         return -1;
     }

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -63,7 +63,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
-    if(!ctx.authValue){
+    if (!ctx.authValue){
         ctx.authValue = "";
     }
     if (!ctx.policyPath) {

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -70,13 +70,12 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         ctx.policyPath = "";
     }
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --path=\n");
+        fprintf (stderr, "No NV path provided, use --path\n");
         return -1;
     }
 
     if (!ctx.nvTemplate) {
-        fprintf (stderr, "No type provided, use --type=[file or" \
-            " '-' for standard input]\n");
+        fprintf (stderr, "No type provided, use --type\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -35,7 +35,7 @@ static bool on_option(char key, char *value) {
     case 't':
         ctx.keyType = value;
         break;
-    case 'd':
+    case 'i':
         ctx.data = value;
         break;
     }
@@ -49,9 +49,9 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"type",        required_argument, NULL, 't'},
         {"policyPath",  required_argument, NULL, 'P'},
         {"authValue",    optional_argument, NULL, 'a'},
-        {"data"       , required_argument, NULL, 'd'}
+        {"data"       , required_argument, NULL, 'i'}
     };
-    return (*opts = tpm2_options_new ("a:p:P:t:d:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("a:p:P:t:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -59,17 +59,17 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "key path missing, use --path=\n");
+        fprintf (stderr, "key path missing, use --path\n");
         free (ctx.authValue);
         return -1;
     }
     if (!ctx.keyType) {
-        fprintf (stderr, "key type missing, use --type=\n");
+        fprintf (stderr, "key type missing, use --type\n");
         free (ctx.authValue);
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "data to seal missing, use --data=\n");
+        fprintf (stderr, "data to seal missing, use --data\n");
         free (ctx.authValue);
         return -1;
     }

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -19,16 +19,16 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'c':
+    case 'i':
         ctx.cipherText = value;
         break;
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'p':
+    case 'o':
         ctx.plainText = value;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
     }
@@ -38,12 +38,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
-        {"cipherText", required_argument, NULL, 'c'},
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"cipherText", required_argument, NULL, 'i'},
         {"force"      , no_argument      , NULL, 'f'},
-        {"plainText"     , required_argument, NULL, 'p'},
+        {"plainText"     , required_argument, NULL, 'o'},
     };
-    return (*opts = tpm2_options_new ("c:f:p:k:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:f:o:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -51,17 +51,15 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "No key path provided, use --keyPath=\n");
+        fprintf (stderr, "No key path provided, use --keyPath\n");
         return -1;
     }
     if (!ctx.cipherText) {
-        fprintf (stderr, "No encrypted text provided, use --cipherText=[file" \
-            " or '-' for standard input]\n");
+        fprintf (stderr, "No encrypted text provided, use --cipherText\n");
         return -1;
     }
     if (!ctx.plainText) {
-        fprintf (stderr, "No output file provided, use --plainText=[file or '-'" \
-            " for standard output]\n");
+        fprintf (stderr, "No output file provided, use --plainText\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_delete.c
+++ b/tools/fapi/tss2_delete.c
@@ -31,7 +31,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (!path) {
-        fprintf (stderr, "No path to the entity provided, use --path=\n");
+        fprintf (stderr, "No path to the entity provided, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -23,16 +23,16 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'p':
+    case 'P':
         ctx.policyPath = value;
         break;
-    case 'c':
+    case 'o':
         ctx.cipherText = value;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
-    case 'P':
+    case 'i':
         ctx.plainText = value;
         break;
     }
@@ -42,13 +42,13 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
-        {"policyPath",  required_argument, NULL, 'p'},
-        {"plainText",   required_argument, NULL, 'P'},
-        {"cipherText",  required_argument, NULL, 'c'},
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"policyPath",  required_argument, NULL, 'P'},
+        {"plainText",   required_argument, NULL, 'i'},
+        {"cipherText",  required_argument, NULL, 'o'},
         {"force",       no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("f:p:c:k:P:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:P:o:p:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -56,17 +56,15 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "No key path provided, use --keyPath=\n");
+        fprintf (stderr, "No key path provided, use --keyPath\n");
         return -1;
     }
     if (!ctx.plainText) {
-        fprintf (stderr, "No text to encrypt provided, use --plainText=[file" \
-            ", or '-' for standard input]\n");
+        fprintf (stderr, "No text to encrypt provided, use --plainText\n");
         return -1;
     }
     if (!ctx.cipherText) {
-        fprintf (stderr, "No output file provided, --cipherText=[file, or " \
-            "'-' for standard output]\n");
+        fprintf (stderr, "No output file provided, --cipherText\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -23,10 +23,10 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'P':
+    case 'e':
         ctx.pathToPublicKeyOfNewParent = value;
         break;
-    case 'e':
+    case 'o':
         ctx.exportedData = value;
         break;
     case 'p':
@@ -39,12 +39,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'P'},
+        {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'e'},
         {"force",                       no_argument      , NULL, 'f'},
-        {"exportedData",                required_argument, NULL, 'e'},
+        {"exportedData",                required_argument, NULL, 'o'},
         {"pathOfKeyToDuplicate",        required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("f:P:e:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:e:o:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -52,11 +52,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.exportedData) {
-        fprintf (stderr, "exported data missing, use --output=\n");
+        fprintf (stderr, "exported data missing, use --output\n");
         return -1;
     }
     if (!ctx.pathOfKeyToDuplicate) {
-        fprintf (stderr, "path of key to duplicate missing, use --path=\n");
+        fprintf (stderr, "path of key to duplicate missing, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -20,7 +20,7 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'a':
+    case 'o':
         ctx.data = value;
         break;
     case 'f':
@@ -37,11 +37,11 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path", required_argument, NULL, 'p'},
-        {"appData", required_argument, NULL, 'a'},
+        {"appData", required_argument, NULL, 'o'},
         {"force" , no_argument, NULL, 'f'},
 
     };
-    return (*opts = tpm2_options_new ("a:f:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -49,7 +49,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -25,7 +25,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.path = value;
         break;
-    case 'x':
+    case 'o':
         ctx.x509cert = value;
         break;
     }
@@ -37,9 +37,9 @@ bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         {"path"    , required_argument, NULL, 'p'},
-        {"x509certData", required_argument, NULL, 'x'}
+        {"x509certData", required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:p:x:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:p:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,11 +47,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path missing, use --path=\n");
+        fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
     if (!ctx.x509cert) {
-        fprintf (stderr, "x509certData missing, use --x509certData=\n");
+        fprintf (stderr, "x509certData missing, use --x509certData\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -22,7 +22,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.path = value;
         break;
-    case 'd':
+    case 'o':
         ctx.description = value;
         break;
     case 'f':
@@ -36,10 +36,10 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"        , required_argument, NULL, 'p'},
-        {"description" , required_argument, NULL, 'd'},
+        {"description" , required_argument, NULL, 'o'},
         {"force"       , no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("d:f:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,11 +47,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
     if (!ctx.description) {
-        fprintf (stderr, "description is missing, use --description=\n");
+        fprintf (stderr, "description is missing, use --description\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -10,7 +10,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
-    char *filename;
+    char *info;
     bool  overwrite;
 } ctx;
 
@@ -20,8 +20,8 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'i':
-        ctx.filename = value;
+    case 'o':
+        ctx.info = value;
         break;
     }
     return true;
@@ -32,30 +32,30 @@ bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         /* output file */
-        {"info"  , required_argument, NULL, 'i'}
+        {"info"  , required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:i:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Execute FAPI command with passed arguments */
-    char *output;
-    TSS2_RC r = Fapi_GetInfo (fctx, &output);
+    char *info;
+    TSS2_RC r = Fapi_GetInfo (fctx, &info);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_GetInfo", r);
         return 1;
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.filename, ctx.overwrite, output, 0);
+    r = open_write_and_close (ctx.info, ctx.overwrite, info, 0);
     if (r) {
         LOG_PERR ("open_write_and_close", r);
-        Fapi_Free (output);
+        Fapi_Free (info);
         return 1;
     }
 
-    Fapi_Free (output);
+    Fapi_Free (info);
     return 0;
 }

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -21,7 +21,7 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'c':
+    case 'o':
         ctx.certificates = value;
         break;
     }
@@ -32,9 +32,9 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force",           no_argument      , NULL, 'f'},
-        {"certificates",    required_argument, NULL, 'c'}
+        {"certificates",    required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:c:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -42,7 +42,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.certificates) {
-        fprintf (stderr, "certificates missing, use --certificates=\n");
+        fprintf (stderr, "certificates missing, use --certificates\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -53,17 +53,17 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         &certificatesSize);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_GetPlatformCertificates", r);
-        if(certificatesSize>0){
+        if (certificatesSize>0){
             Fapi_Free (certificates);
         }
         return 1;
     }
 
     /* Write returned data to file(s) */
-    if(certificatesSize>0){
+    if (certificatesSize>0){
         r = open_write_and_close (ctx.certificates, ctx.overwrite,
             certificates, certificatesSize);
-        if(r){
+        if (r){
             LOG_PERR ("open_write_and_close certificates", r);
             Fapi_Free (certificates);
             return 1;

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -78,7 +78,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.filename, ctx.overwrite, output,
         ctx.numBytes);
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close output", r);
         Fapi_Free (output);
         return 1;

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -100,7 +100,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         Fapi_Free (tpm2bPublic);
         return 1;
     }
-    if(policy){
+    if (policy){
         r = open_write_and_close (ctx.policy, ctx.overwrite, policy,
             strlen(policy));
         if (r){

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -57,19 +57,19 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path missing, use --path=\n");
+        fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
     if (!ctx.tpm2bPublic) {
-        fprintf (stderr, "public missing, use --tpm2bPublic=\n");
+        fprintf (stderr, "public missing, use --tpm2bPublic\n");
         return -1;
     }
     if (!ctx.tpm2bPrivate) {
-        fprintf (stderr, "private missing, use --tpm2bPrivate=\n");
+        fprintf (stderr, "private missing, use --tpm2bPrivate\n");
         return -1;
     }
     if (!ctx.policy) {
-        fprintf (stderr, "policy missing, use --policy=\n");
+        fprintf (stderr, "policy missing, use --policy\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 's':
+    case 'p':
         ctx.searchPath = value;
         break;
-    case 'p':
+    case 'o':
         ctx.pathList = value ? value : "-";
         break;
     }
@@ -31,10 +31,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"searchPath" , optional_argument, NULL, 's'},
-        {"pathList" , optional_argument, NULL, 'p'}
+        {"searchPath" , optional_argument, NULL, 'p'},
+        {"pathList" , optional_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("s:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -42,23 +42,23 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     (void) fctx;
     /* Execute FAPI command with passed arguments */
-    char *pathlist = NULL;
+    char *pathList = NULL;
     TSS2_RC r = Fapi_List(fctx,
-        ctx.searchPath ? ctx.searchPath : "", &pathlist);
+        ctx.searchPath ? ctx.searchPath : "", &pathList);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_List", r);
         return 1;
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.pathList, true, pathlist,
-        strlen(pathlist));
+    r = open_write_and_close (ctx.pathList, true, pathList,
+        strlen(pathList));
     if (r){
-        LOG_PERR ("open_write_and_close pathlist", r);
-        Fapi_Free (pathlist);
+        LOG_PERR ("open_write_and_close pathList", r);
+        Fapi_Free (pathList);
         return 1;
     }
 
-    Fapi_Free (pathlist);
+    Fapi_Free (pathList);
     return 0;
 }

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -65,7 +65,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     char *logData = NULL;
-    if(ctx.logData){
+    if (ctx.logData){
         TSS2_RC r = open_read_and_close (ctx.logData, (void**)&logData, 0);
         if (r){
             LOG_PERR ("open_read_and_close logData", r);
@@ -81,7 +81,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
     Fapi_Free (data);
-    if(logData){
+    if (logData){
         Fapi_Free (logData);
     }
 

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'd':
+    case 'i':
         ctx.data = value;
         break;
-    case 'n':
+    case 'p':
         ctx.nvPath = value;
         break;
     case 'l':
@@ -34,11 +34,11 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"data"  , required_argument, NULL, 'd'},
-        {"nvPath"  , required_argument, NULL, 'n'},
+        {"data"  , required_argument, NULL, 'i'},
+        {"nvPath"  , required_argument, NULL, 'p'},
         {"logData"  , required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("d:n:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -46,12 +46,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "No file for input provided, use --data=[filename or "\
-            "'-' for standard input]\n");
+        fprintf (stderr, "No file for input provided, use --data\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvincrement.c
+++ b/tools/fapi/tss2_nvincrement.c
@@ -13,7 +13,7 @@ static char const *nvPath;
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'n':
+    case 'p':
         nvPath = value;
         break;
     }
@@ -23,9 +23,9 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"nvPath", required_argument, NULL, 'n'}
+        {"nvPath", required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("n:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -33,7 +33,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!nvPath) {
-        fprintf (stderr, "No path to the NV provided, use --nvPath=\n");
+        fprintf (stderr, "No path to the NV provided, use --nvPath\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -78,7 +78,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             LOG_PERR ("open_write_and_close data", r);
             return 1;
         }
-        if(logData){
+        if (logData){
             r = open_write_and_close (ctx.logData, ctx.overwrite, logData, strlen(logData));
             if (r){
                 Fapi_Free (data);

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -24,10 +24,10 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'd':
+    case 'o':
         ctx.data = value;
         break;
-    case 'n':
+    case 'p':
         ctx.nvPath = value;
         break;
     case 'l':
@@ -40,12 +40,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"nvPath"  , required_argument, NULL, 'n'},
+        {"nvPath"  , required_argument, NULL, 'p'},
         {"force" , no_argument      , NULL, 'f'},
-        {"data", required_argument, NULL, 'd'},
+        {"data", required_argument, NULL, 'o'},
         {"logData", required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("f:d:n:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:o:p:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -53,12 +53,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "No file for output provided, use --data=[filename "\
-            "or '-' for standard output]\n");
+        fprintf (stderr, "No file for output provided, use --data\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvsetbits.c
+++ b/tools/fapi/tss2_nvsetbits.c
@@ -15,8 +15,8 @@ static struct cxt {
 
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
-    switch(key) {
-    case 'b': {
+    switch (key) {
+    case 'i': {
         uint64_t i;
         if (!tpm2_util_string_to_uint64 (value, &i) || i == 0) {
             fprintf (stderr, "%s cannot be converted to a positive integer or "\
@@ -26,7 +26,7 @@ static bool on_option(char key, char *value) {
         ctx.bitmap = i; /* cast from uint32 to size_t */
         }
         break;
-    case 'n':
+    case 'p':
         ctx.path = value;
         break;
     }
@@ -36,10 +36,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"bitmap", required_argument, NULL, 'b'},
-        {"nvPath"    , required_argument, NULL, 'n'}
+        {"bitmap", required_argument, NULL, 'i'},
+        {"nvPath"    , required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("b:n:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,11 +47,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "No path to the NV provided, use --nvPath=\n");
+        fprintf (stderr, "No path to the NV provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.bitmap) {
-        fprintf (stderr, "No bits provided, use --bitmap=0x...\n");
+        fprintf (stderr, "No bits provided, use --bitmap [0x...]\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -20,10 +20,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'c':
+    case 'o':
         ctx.pcrValue = value;
         break;
-    case 'i':
+    case 'x':
         if (!tpm2_util_string_to_uint32 (value, &ctx.pcrIndex)) {
             fprintf (stderr, "The PCR index must be an integer less than "\
                 "2**32-1\n");
@@ -43,12 +43,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"pcrIndex"     , required_argument, NULL, 'i'},
-        {"pcrValue"     , required_argument, NULL, 'c'},
+        {"pcrIndex"     , required_argument, NULL, 'x'},
+        {"pcrValue"     , required_argument, NULL, 'o'},
         {"force"         , no_argument      , NULL, 'f'},
         {"pcrLog"       , required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("c:i:f:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:x:f:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -56,15 +56,15 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.pcrIndex) {
-        fprintf (stderr, "No PCR index provided, use --pcrIndex=\n");
+        fprintf (stderr, "No PCR index provided, use --pcrIndex\n");
         return -1;
     }
     if (!ctx.pcrValue) {
-        fprintf (stderr, "No PCR value provided, use --pcrValue=\n");
+        fprintf (stderr, "No PCR value provided, use --pcrValue\n");
         return -1;
     }
     if (!ctx.pcrLog) {
-        fprintf (stderr, "No PCR log provided, use --pcrLog=\n");
+        fprintf (stderr, "No PCR log provided, use --pcrLog\n");
         return -1;
     }
     if (!strcmp (ctx.pcrLog, "-") && !strcmp (ctx.pcrValue, "-")) {
@@ -94,7 +94,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (pcrLog){
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
     }
-    else{
+    else {
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, "", 0);
     }
     if (r){

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -87,27 +87,27 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.pcrValue, ctx.overwrite, pcrValue,
         pcrValueSize);
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close pcrValue", r);
         return 1;
     }
-    if(pcrLog){
+    if (pcrLog){
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
     }
     else{
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, "", 0);
     }
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close pcrLog", r);
         Fapi_Free (pcrValue);
-        if(pcrLog){
+        if (pcrLog){
             Fapi_Free (pcrLog);
         }
         return 1;
     }
 
     Fapi_Free (pcrValue);
-    if(pcrLog){
+    if (pcrLog){
         Fapi_Free (pcrLog);
     }
     return r;

--- a/tools/fapi/tss2_provision.c
+++ b/tools/fapi/tss2_provision.c
@@ -16,13 +16,13 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'e':
+    case 'E':
         ctx.authValueEh = value;
         break;
-    case 's':
+    case 'S':
         ctx.authValueSh = value;
         break;
-    case 'l':
+    case 'L':
         ctx.authValueLockout = value;
         break;
     }
@@ -32,11 +32,11 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"authValueEh",         required_argument, NULL, 'e'},
-        {"authValueSh",         required_argument, NULL, 's'},
-        {"authValueLockout",    required_argument, NULL, 'l'},
+        {"authValueEh",         required_argument, NULL, 'E'},
+        {"authValueSh",         required_argument, NULL, 'S'},
+        {"authValueLockout",    required_argument, NULL, 'L'},
     };
-    return (*opts = tpm2_options_new ("e:s:l",
+    return (*opts = tpm2_options_new ("E:S:L",
         ARRAY_LEN(topts), topts, on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -179,10 +179,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close quoteInfo", r);
         Fapi_Free (quoteInfo);
-        if(pcrEventLog){
+        if (pcrEventLog){
             Fapi_Free (pcrEventLog);
         }
         Fapi_Free (signature);
@@ -191,10 +191,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     Fapi_Free (quoteInfo);
 
-    if(pcrEventLog){
+    if (pcrEventLog){
         r = open_write_and_close (ctx.pcrEventLog, ctx.overwrite, pcrEventLog,
             0);
-        if(r){
+        if (r){
             LOG_PERR ("open_write_and_close pcrEventLog", r);
             Fapi_Free (pcrEventLog);
             Fapi_Free (signature);

--- a/tools/fapi/tss2_setappdata.c
+++ b/tools/fapi/tss2_setappdata.c
@@ -20,7 +20,7 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'a':
+    case 'i':
         ctx.data_size = strlen(value);
         ctx.data = (uint8_t*) value;
         break;
@@ -34,10 +34,10 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"appData", required_argument, NULL, 'a'},
+        {"appData", required_argument, NULL, 'i'},
         {"path", required_argument, NULL, 'p'},
     };
-    return (*opts = tpm2_options_new ("a:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -45,7 +45,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -19,7 +19,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.path = value;
         break;
-    case 'x':
+    case 'i':
         ctx.x509cert = value;
         break;
     }
@@ -30,9 +30,9 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"    , required_argument, NULL, 'p'},
-        {"x509certData", required_argument, NULL, 'x'}
+        {"x509certData", required_argument, NULL, 'i'}
     };
-    return (*opts = tpm2_options_new ("p:x:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:i", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -40,11 +40,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path missing, use --path=\n");
+        fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
     if (!ctx.x509cert) {
-        fprintf (stderr, "x509certData missing, use --x509certData=\n");
+        fprintf (stderr, "x509certData missing, use --x509certData\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_setdescription.c
+++ b/tools/fapi/tss2_setdescription.c
@@ -16,7 +16,7 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'd':
+    case 'i':
         if (value && strlen (value) > 1023) {
             fprintf (stderr, "The description can be at most 1023 octets\n");
             return false;
@@ -33,10 +33,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"description", required_argument, NULL, 'd'},
+        {"description", required_argument, NULL, 'i'},
         {"path"       , required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("d:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -44,11 +44,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
     if (!ctx.description) {
-        fprintf (stderr, "description is missing, use --description=\n");
+        fprintf (stderr, "description is missing, use --description\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -81,7 +81,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "signature missing, use --signature=\n");
         return -1;
     }
-    if(ctx.publicKey && ctx.certificate){
+    if (ctx.publicKey && ctx.certificate){
         if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) +
             !strcmp("-", ctx.certificate ? ctx.certificate : "") > 1) {
             fprintf (stderr, "At most one of --certificate, --publicKey and "\
@@ -89,14 +89,14 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             return -1;
         }
     }
-    if(ctx.publicKey && !ctx.certificate){
+    if (ctx.publicKey && !ctx.certificate){
         if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) > 1) {
             fprintf (stderr, "At most one of --publicKey and --signature can "\
                 "be '-' (standard output)\n");
             return -1;
         }
     }
-    if(ctx.certificate && !ctx.publicKey){
+    if (ctx.certificate && !ctx.publicKey){
         if (!strcmp ("-", ctx.signature) + !strcmp("-",
             ctx.certificate ? ctx.certificate : "") > 1) {
             fprintf (stderr, "At most one of --certificate and --signature can"\
@@ -115,7 +115,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
 
-    if(ctx.certificate){
+    if (ctx.certificate){
         r = open_read_and_close (ctx.certificate, (void**)&certificate,
             &digestSize);
         if (r){
@@ -137,7 +137,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Write returned data to file(s) */
     if (ctx.certificate) {
-        if(certificate && strlen(certificate)){
+        if (certificate && strlen(certificate)){
             r = open_write_and_close (ctx.certificate, ctx.overwrite,
                 certificate, strlen(certificate));
             if (r) {

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -33,16 +33,16 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
-    case 'p':
+    case 'k':
         ctx.publicKey = value;
         break;
-    case 's':
+    case 'o':
         ctx.signature = value;
         break;
-    case 'P':
+    case 's':
         ctx.padding = value;
         break;
     }
@@ -52,16 +52,16 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
-        {"padding",     required_argument, NULL, 'P'},
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"padding",     required_argument, NULL, 's'},
         {"digest",      required_argument, NULL, 'd'},
-        {"signature",   required_argument, NULL, 's'},
-        {"publicKey",   required_argument, NULL, 'p'},
+        {"signature",   required_argument, NULL, 'o'},
+        {"publicKey",   required_argument, NULL, 'k'},
         {"force",       no_argument      , NULL, 'f'},
         {"certificate", required_argument, NULL, 'c'},
 
     };
-    return (*opts = tpm2_options_new ("c:d:f:k:p:s:P:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("c:d:f:p:k:o:s:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -70,15 +70,15 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Check availability of required parameters */
     if (!ctx.digest) {
-        fprintf (stderr, "digest missing, use --digest=\n");
+        fprintf (stderr, "digest missing, use --digest\n");
         return -1;
     }
     if (!ctx.keyPath) {
-        fprintf (stderr, "key path missing, use --keyPath=\n");
+        fprintf (stderr, "key path missing, use --keyPath\n");
         return -1;
     }
     if (!ctx.signature) {
-        fprintf (stderr, "signature missing, use --signature=\n");
+        fprintf (stderr, "signature missing, use --signature\n");
         return -1;
     }
     if (ctx.publicKey && ctx.certificate){
@@ -113,15 +113,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (r){
         LOG_PERR ("open_read_and_close digest", r);
         return 1;
-    }
-
-    if (ctx.certificate){
-        r = open_read_and_close (ctx.certificate, (void**)&certificate,
-            &digestSize);
-        if (r){
-            LOG_PERR ("open_read_and_close certificate", r);
-            return 1;
-        }
     }
 
     /* Execute FAPI command with passed arguments */

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -265,7 +265,7 @@ TSS2_RC branch_callback(
 static FAPI_CONTEXT* ctx_init(char const * uri) {
     FAPI_CONTEXT* ret;
     const unsigned int rval = Fapi_Initialize(&ret, uri);
-    if(rval != TSS2_RC_SUCCESS){
+    if (rval != TSS2_RC_SUCCESS){
         LOG_PERR("Fapi_Initialize", rval);
         return NULL;
     }

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -10,7 +10,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed command line parameters */
 static struct cxt {
-    char const *keyPath;
+    char const *path;
     char const *data;
     bool        overwrite;
 } ctx;
@@ -22,9 +22,9 @@ static bool on_option(char key, char *value) {
         ctx.overwrite = true;
         break;
     case 'p':
-        ctx.keyPath = value;
+        ctx.path = value;
         break;
-    case 'd':
+    case 'o':
         ctx.data = value;
         break;
     }
@@ -35,29 +35,29 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path",    required_argument, NULL, 'p'},
-        {"data",    required_argument, NULL, 'd'},
+        {"data",    required_argument, NULL, 'o'},
         {"force",   no_argument, NULL, 'f'}
     };
-    return (*opts = tpm2_options_new ("p:d:f", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:o:f", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
-    if (!ctx.keyPath) {
-        fprintf (stderr, "path to the sealed data missing, use --path=\n");
+    if (!ctx.path) {
+        fprintf (stderr, "path to the sealed data missing, use --path\n");
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "path to decrypted data missing, use --data=\n");
+        fprintf (stderr, "path to decrypted data missing, use --data\n");
         return -1;
     }
 
     /* Execute FAPI command with passed arguments */
     uint8_t *data;
     size_t size;
-    TSS2_RC r = Fapi_Unseal (fctx, ctx.keyPath, &data, &size);
+    TSS2_RC r = Fapi_Unseal (fctx, ctx.path, &data, &size);
     if (r != TSS2_RC_SUCCESS){
         LOG_PERR ("Fapi_Unseal", r);
         return 1;

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -113,7 +113,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         free (signature);
         return -1;
     }
-    if(pcrEventLog){
+    if (pcrEventLog){
         r = open_read_and_close (ctx.pcrEventLog, (void**)&pcrEventLog, NULL);
         if (r) {
             LOG_PERR ("open_read_and_close pcrEventLog", r);

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -22,10 +22,10 @@ static bool on_option(char key, char *value) {
     case 'd':
         ctx.digest = value;
         break;
-    case 'k':
+    case 'p':
         ctx.publicKeyPath = value;
         break;
-    case 's':
+    case 'i':
         ctx.signature = value;
         break;
     }
@@ -35,11 +35,11 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
+        {"keyPath",     required_argument, NULL, 'p'},
         {"digest",      required_argument, NULL, 'd'},
-        {"signature",   required_argument, NULL, 's'}
+        {"signature",   required_argument, NULL, 'i'}
     };
-    return (*opts = tpm2_options_new ("d:k:s:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("d:p:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -48,20 +48,20 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.publicKeyPath) {
         fprintf (stderr, "public key path parameter not provided, use " \
-            "--keyPath=\n");
+            "--keyPath\n");
         return -1;
     }
     if (!ctx.digest) {
-        fprintf (stderr, "digest parameter not provided, use --digest=\n");
+        fprintf (stderr, "digest parameter not provided, use --digest\n");
         return -1;
     }
     if (!ctx.signature) {
         fprintf (stderr, "signature parameter not provided, use "\
-            "--signature=\n");
+            "--signature\n");
         return -1;
     }
     if (!strcmp ("-", ctx.signature)  && !strcmp("-", ctx.digest)) {
-        fprintf (stderr, "At most one of --signature= and --digest= can be '-'"\
+        fprintf (stderr, "At most one of --signature and --digest can be '-'"\
             " (standard input)\n");
         return -1;
     }

--- a/tools/fapi/tss2_writeauthorizenv.c
+++ b/tools/fapi/tss2_writeauthorizenv.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'n':
+    case 'p':
         ctx.nvPath = value;
         break;
-    case 'l':
+    case 'P':
         ctx.policyPath = value;
         break;
     }
@@ -31,10 +31,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"nvPath"  , required_argument, NULL, 'n'},
-        {"policyPath"  , required_argument, NULL, 'l'}
+        {"nvPath"  , required_argument, NULL, 'p'},
+        {"policyPath"  , required_argument, NULL, 'P'}
     };
-    return (*opts = tpm2_options_new ("n:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:P:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -42,11 +42,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.policyPath) {
-        fprintf (stderr, "No policy path provided, use --policyPath=\n");
+        fprintf (stderr, "No policy path provided, use --policyPath\n");
         return -1;
     }
 


### PR DESCRIPTION
This commit fixes consistency of tss2_* tools.

* Code Formatting: Formatting was inconsistent with the rest of the tools. Now there is space included after key words also for FAPI tools.
* Options: Short options are now consistent across the tss2_* tools. Also, long options are not using '=' anymore.


Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>