### PR TITLE
Fix for failing FAPI integration test and wrong interface

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -3,7 +3,7 @@
 
 function get_deps() {
 
-	TSS_VERSION="2.3.1"
+	TSS_VERSION=master
 	ABRMD_VERSION="2.3.0"
 
 	echo "pwd starting: `pwd`"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+ * tpm2_policyor: List of policy files should be specified as an argument
+   instead of -l option. The -l option is still retained for backwards
+   compatibility. See issue#1894.
+
  * tpm2\_eventlog: add a tool for parsing and displaying the event log.
 
 ### 4.1.1 - 2020-01-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### 4.1.1-RC1 - 2020-01-13
+### 4.1.1 - 2020-01-21
 
 * tpm2\_certify: Fix output of attestation data including size field. Now outputs just bytes.
 * tpm2\_certifycreation: Fix tool to match manpage where the code had the -C and -c options reversed.
@@ -10,7 +10,7 @@
 * tpm2\_import: Support object policies when importing raw key material.
 * Fix overflow in pcrs.h where sizeof() was used instead of ARRAY\_LEN().
 * build:
-  - Fix compilation inssue: lib/tpm2\_hash.c:17:19: note: 'left' was declared here.
+  - Fix compilation issue: lib/tpm2\_hash.c:17:19: note: 'left' was declared here.
 * man:
     - Fix manpage examples that have "sha" instead of "sha1"
     - tpm2\_shutdown manpage was missing, add it to build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### next
+
+ * tpm2\_eventlog: add a tool for parsing and displaying the event log.
+
 ### 4.1.1 - 2020-01-21
 
 * tpm2\_certify: Fix output of attestation data including size field. Now outputs just bytes.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,10 +24,15 @@ To build and install the tpm2-tools software the following software is required:
 
 #### Optional Dependencies:
   * To build the man pages you need [pandoc](https://github.com/jgm/pandoc)
+  * FAPI - TPM2.0 TSS FAPI library (tss2-fapi) and header files
   * To enable the new userspace resource manager, one must get tpm2-tabrmd
     (**recommended**).
-  * For the tests: tpm2-abrmd (must be on $PATH) and tpm_server
-  * Some tests pass only if xxd, bash and python with PyYAML are available
+  * When ./configure is invoked with --enable-unit or --enable-unit=abrmd,
+    the tests are run towards a resource manager, tpm2-abrmd, which must be on $PATH.
+  * When ./configure is invoked with --enable-unit=mssim, the tests are run directly
+    towards tpm_server, without resource manager.
+  * For the tests, with or without resource manager, tpm_server must be installed.
+  * Some tests pass only if xxd, expect, bash and python with PyYAML are available
   * Some tests optionally use (but do not require) curl
 
 ### Typical Distro Dependency Installation

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ Copyright 2017      Alibaba Group
 Copyright 2015-2017 Atom Software Studios, s.r.o.
 Copyright 2017      Emmanuel Deloget <logout@free.fr>
 Copyright 2018-2019 Fraunhofer SIT
+Copyright 2019      Fraunhofer SIT sponsored by Infineon Technologies AG
 Copyright 2019      GlovePuppet
 Copyright 2015-2019 Intel Corporation
 Copyright 2019      Massachusetts Institute of Technology

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,54 @@ LDADD = \
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-bashcompdir='$$(datarootdir)/bash-completion/completions'
 
 # keep me sorted
-bin_PROGRAMS = \
+bin_PROGRAMS =
+FAPI_CFLAGS = $(EXTRA_CFLAGS) $(TSS2_FAPI_CFLAGS) $(CODE_COVERAGE_CFLAGS)
+TESTS =
+
+if HAVE_FAPI
+
+bin_PROGRAMS += \
+    tools/fapi/tss2_decrypt \
+    tools/fapi/tss2_encrypt \
+    tools/fapi/tss2_list \
+    tools/fapi/tss2_changeauth \
+    tools/fapi/tss2_delete \
+    tools/fapi/tss2_import \
+    tools/fapi/tss2_getinfo \
+    tools/fapi/tss2_createkey \
+    tools/fapi/tss2_createseal \
+    tools/fapi/tss2_exportkey \
+    tools/fapi/tss2_getcertificate \
+    tools/fapi/tss2_getplatformcertificates \
+    tools/fapi/tss2_gettpmblobs \
+    tools/fapi/tss2_getappdata \
+    tools/fapi/tss2_setappdata \
+    tools/fapi/tss2_setcertificate \
+    tools/fapi/tss2_sign \
+    tools/fapi/tss2_verifysignature \
+    tools/fapi/tss2_verifyquote \
+    tools/fapi/tss2_createnv \
+    tools/fapi/tss2_nvextend \
+    tools/fapi/tss2_nvincrement \
+    tools/fapi/tss2_nvread \
+    tools/fapi/tss2_nvsetbits \
+    tools/fapi/tss2_nvwrite \
+    tools/fapi/tss2_getdescription \
+    tools/fapi/tss2_setdescription \
+    tools/fapi/tss2_pcrextend \
+    tools/fapi/tss2_quote \
+    tools/fapi/tss2_pcrread \
+    tools/fapi/tss2_authorizepolicy \
+    tools/fapi/tss2_exportpolicy \
+    tools/fapi/tss2_import \
+    tools/fapi/tss2_provision \
+    tools/fapi/tss2_getrandom \
+    tools/fapi/tss2_unseal \
+    tools/fapi/tss2_writeauthorizenv
+
+endif
+
+bin_PROGRAMS += \
     tools/misc/tpm2_checkquote \
     tools/misc/tpm2_eventlog \
     tools/misc/tpm2_print \
@@ -125,6 +172,151 @@ lib_libcommon_a_SOURCES = $(LIB_SRC)
 lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS)
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
 
+tools_fapi_tss2_decrypt_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_decrypt_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_decrypt_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_template.h \
+    tools/fapi/tss2_decrypt.c
+
+tools_fapi_tss2_encrypt_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_encrypt_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_encrypt_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_encrypt.c
+
+tools_fapi_tss2_list_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_list_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_list_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_list.c
+
+tools_fapi_tss2_changeauth_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_changeauth_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_changeauth_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_changeauth.c
+
+tools_fapi_tss2_delete_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_delete_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_delete_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_delete.c
+
+tools_fapi_tss2_import_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_import_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_import_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_import.c
+
+tools_fapi_tss2_createkey_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_createkey_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_createkey_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_createkey.c
+
+tools_fapi_tss2_createseal_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_createseal_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_createseal_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_createseal.c
+
+tools_fapi_tss2_getcertificate_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_getcertificate_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_getcertificate_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getcertificate.c
+
+tools_fapi_tss2_getplatformcertificates_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_getplatformcertificates_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_getplatformcertificates_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getplatformcertificates.c
+
+tools_fapi_tss2_gettpmblobs_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_gettpmblobs_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_gettpmblobs_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_gettpmblobs.c
+
+tools_fapi_tss2_getappdata_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_getappdata_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_getappdata_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getappdata.c
+
+tools_fapi_tss2_setappdata_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_setappdata_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_setappdata_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_setappdata.c
+
+tools_fapi_tss2_exportkey_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_exportkey_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_exportkey_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_exportkey.c
+
+tools_fapi_tss2_setcertificate_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_setcertificate_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_setcertificate_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_setcertificate.c
+
+tools_fapi_tss2_sign_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_sign_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_sign_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_sign.c
+
+tools_fapi_tss2_verifysignature_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_verifysignature_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_verifysignature_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_verifysignature.c
+
+tools_fapi_tss2_verifyquote_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_verifyquote_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_verifyquote_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_verifyquote.c
+
+tools_fapi_tss2_createnv_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_createnv_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_createnv_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_createnv.c
+
+tools_fapi_tss2_nvextend_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_nvextend_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_nvextend_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvextend.c
+
+tools_fapi_tss2_nvincrement_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_nvincrement_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_nvincrement_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvincrement.c
+
+tools_fapi_tss2_nvread_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_nvread_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_nvread_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvread.c
+
+tools_fapi_tss2_nvsetbits_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_nvsetbits_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_nvsetbits_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvsetbits.c
+
+tools_fapi_tss2_nvwrite_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_nvwrite_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_nvwrite_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvwrite.c
+
+tools_fapi_tss2_getinfo_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_getinfo_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_getinfo_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getinfo.c
+
+tools_fapi_tss2_getdescription_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_getdescription_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_getdescription_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getdescription.c
+
+tools_fapi_tss2_setdescription_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_setdescription_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_setdescription_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_setdescription.c
+
+tools_fapi_tss2_pcrextend_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_pcrextend_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_pcrextend_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_pcrextend.c
+
+tools_fapi_tss2_quote_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_quote_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_quote_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_quote.c
+
+tools_fapi_tss2_pcrread_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_pcrread_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_pcrread_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_pcrread.c
+
+tools_fapi_tss2_authorizepolicy_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_authorizepolicy_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_authorizepolicy_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_authorizepolicy.c
+
+tools_fapi_tss2_exportpolicy_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_exportpolicy_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_exportpolicy_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_exportpolicy.c
+
+tools_fapi_tss2_unseal_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_unseal_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_unseal_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_unseal.c
+
+tools_fapi_tss2_provision_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_provision_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_provision_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_provision.c
+
+tools_fapi_tss2_getrandom_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_getrandom_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_getrandom_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getrandom.c
+
+tools_fapi_tss2_writeauthorizenv_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_writeauthorizenv_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_writeauthorizenv_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_writeauthorizenv.c
+
 tools_misc_tpm2_checkquote_SOURCES = tools/misc/tpm2_checkquote.c $(TOOL_SRC)
 tools_misc_tpm2_eventlog_SOURCES = tools/misc/tpm2_eventlog.c $(TOOL_SRC)
 tools_misc_tpm2_print_SOURCES = tools/misc/tpm2_print.c $(TOOL_SRC)
@@ -217,7 +409,7 @@ tools_tpm2_nvextend_SOURCES = tools/tpm2_nvextend.c $(TOOL_SRC)
 tools_tpm2_gettime_SOURCES = tools/tpm2_gettime.c $(TOOL_SRC)
 
 if UNIT
-TESTS = $(check_PROGRAMS)
+TESTS += $(check_PROGRAMS)
 check_PROGRAMS = \
     test/unit/test_string_bytes \
     test/unit/test_files \
@@ -236,6 +428,10 @@ check_PROGRAMS = \
     test/unit/test_tpm2_eventlog_yaml
 
 TESTS += $(ALL_SYSTEM_TESTS)
+
+if HAVE_FAPI
+TESTS += $(ALL_FAPI_TESTS)
+endif
 
 test_unit_test_string_bytes_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_string_bytes_LDADD    = $(CMOCKA_LIBS) $(LDADD)
@@ -310,6 +506,7 @@ AM_TESTS_ENVIRONMENT =	\
 	TPM2_SIM=tpm_server; export TPM2_SIM; \
 	PATH=$(abs_builddir)/tools:$(abs_builddir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH); \
 	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures; \
+	SRCDIR=$(abs_srcdir); export SRCDIR; BUILDDIR=$(abs_builddir); export BUILDDIR; \
 	export TPM2_TOOLS_TEST_FIXTURES;
 
 SH_LOG_COMPILER = dbus-run-session bash
@@ -428,6 +625,47 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_testparms.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
+
+if HAVE_FAPI
+dist_man1_MANS += \
+    man/man1/tss2_list.1 \
+    man/man1/tss2_changeauth.1 \
+    man/man1/tss2_delete.1 \
+    man/man1/tss2_import.1 \
+    man/man1/tss2_decrypt.1 \
+    man/man1/tss2_encrypt.1 \
+    man/man1/tss2_getinfo.1 \
+    man/man1/tss2_createnv.1 \
+    man/man1/tss2_nvread.1 \
+    man/man1/tss2_nvextend.1 \
+    man/man1/tss2_nvincrement.1 \
+    man/man1/tss2_nvsetbits.1 \
+    man/man1/tss2_nvwrite.1 \
+    man/man1/tss2_createkey.1 \
+    man/man1/tss2_createseal.1 \
+    man/man1/tss2_getcertificate.1 \
+    man/man1/tss2_getplatformcertificates.1 \
+    man/man1/tss2_gettpmblobs.1 \
+    man/man1/tss2_getappdata.1 \
+    man/man1/tss2_setappdata.1 \
+    man/man1/tss2_setcertificate.1 \
+    man/man1/tss2_exportkey.1 \
+    man/man1/tss2_sign.1 \
+    man/man1/tss2_verifysignature.1 \
+    man/man1/tss2_verifyquote.1 \
+    man/man1/tss2_getdescription.1 \
+    man/man1/tss2_setdescription.1 \
+    man/man1/tss2_pcrextend.1 \
+    man/man1/tss2_quote.1 \
+    man/man1/tss2_pcrread.1 \
+    man/man1/tss2_provision.1 \
+    man/man1/tss2_authorizepolicy.1 \
+    man/man1/tss2_exportpolicy.1 \
+    man/man1/tss2_unseal.1 \
+    man/man1/tss2_import.1 \
+    man/man1/tss2_getrandom.1 \
+    man/man1/tss2_writeauthorizenv.1
+endif
 endif
 
 MARKDOWN_COMMON_DEPS = \
@@ -454,6 +692,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[common options\]/d' \
 	    -e '/\[common tcti options\]/r $(top_srcdir)/man/common/tcti.md' \
 	    -e '/\[common tcti options\]/d' \
+	    -e '/\[common tss2 options\]/r $(top_srcdir)/man/common/tss2-options.md' \
+	    -e '/\[common tss2 options\]/d' \
 	    -e '/\[authorization formatting\]/r $(top_srcdir)/man/common/authorizations.md' \
 	    -e '/\[authorization formatting\]/d' \
 	    -e '/\[context object format\]/r $(top_srcdir)/man/common/ctxobj.md' \
@@ -490,17 +730,56 @@ CLEANFILES = $(dist_man1_MANS)
 
 bashcompdir=@bashcompdir@
 dist_bashcomp_DATA=dist/bash-completion/tpm2-tools/tpm2_completion.bash
+if HAVE_FAPI
+dist_bashcomp_DATA+= \
+	dist/bash-completion/tpm2-tools/tss2_decrypt \
+	dist/bash-completion/tpm2-tools/tss2_encrypt \
+	dist/bash-completion/tpm2-tools/tss2_list \
+	dist/bash-completion/tpm2-tools/tss2_changeauth \
+	dist/bash-completion/tpm2-tools/tss2_delete \
+	dist/bash-completion/tpm2-tools/tss2_import \
+	dist/bash-completion/tpm2-tools/tss2_getinfo \
+	dist/bash-completion/tpm2-tools/tss2_createkey \
+    dist/bash-completion/tpm2-tools/tss2_createseal \
+	dist/bash-completion/tpm2-tools/tss2_exportkey \
+	dist/bash-completion/tpm2-tools/tss2_getcertificate \
+    dist/bash-completion/tpm2-tools/tss2_getplatformcertificates \
+    dist/bash-completion/tpm2-tools/tss2_gettpmblobs \
+	dist/bash-completion/tpm2-tools/tss2_setcertificate \
+    dist/bash-completion/tpm2-tools/tss2_getappdata \
+    dist/bash-completion/tpm2-tools/tss2_setappdata \
+	dist/bash-completion/tpm2-tools/tss2_sign \
+	dist/bash-completion/tpm2-tools/tss2_verifysignature \
+	dist/bash-completion/tpm2-tools/tss2_verifyquote \
+	dist/bash-completion/tpm2-tools/tss2_createnv \
+	dist/bash-completion/tpm2-tools/tss2_nvextend \
+	dist/bash-completion/tpm2-tools/tss2_nvincrement \
+	dist/bash-completion/tpm2-tools/tss2_nvread \
+	dist/bash-completion/tpm2-tools/tss2_nvsetbits \
+	dist/bash-completion/tpm2-tools/tss2_nvwrite \
+	dist/bash-completion/tpm2-tools/tss2_getdescription \
+	dist/bash-completion/tpm2-tools/tss2_setdescription \
+	dist/bash-completion/tpm2-tools/tss2_pcrextend \
+	dist/bash-completion/tpm2-tools/tss2_quote \
+	dist/bash-completion/tpm2-tools/tss2_pcrread \
+	dist/bash-completion/tpm2-tools/tss2_authorizepolicy \
+	dist/bash-completion/tpm2-tools/tss2_exportpolicy \
+	dist/bash-completion/tpm2-tools/tss2_provision \
+	dist/bash-completion/tpm2-tools/tss2_getrandom \
+	dist/bash-completion/tpm2-tools/tss2_unseal \
+	dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
+endif
 
 install-data-hook:
 	cd $(DESTDIR)$(bashcompdir) && \
 	for tool in $(bin_PROGRAMS); do \
-		$(LN_S) -f tpm2_completion.bash $${tool##*/}; \
+		[ "$${tool}" = "$${tool#tools/fapi/*}" ] && $(LN_S) -f tpm2_completion.bash $${tool##*/}; \
 	done
 
 uninstall-hook:
 	cd $(DESTDIR)$(bashcompdir) && \
 	for tool in $(bin_PROGRAMS); do \
-		[ -L $${tool##*/} ] && rm -f $${tool##*/}; \
+		[ "$${tool}" = "$${tool#tools/fapi/*}" -a -L $${tool##*/} ] && rm -f $${tool##*/}; \
 	done
 
 dist-hook:

--- a/bootstrap
+++ b/bootstrap
@@ -25,6 +25,9 @@ echo "Generating file lists: ${VARS_FILE}"
 
   src_listvar "test/integration/tests" "*.sh" "SYSTEM_TESTS"
   printf "ALL_SYSTEM_TESTS = \$(SYSTEM_TESTS)\n"
+
+  src_listvar "test/integration/fapi" "*.sh" "FAPI_TESTS"
+  printf "ALL_FAPI_TESTS = \$(FAPI_TESTS)\n"
 ) > ${VARS_FILE}
 
 mkdir -p m4

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,17 @@ AM_CONDITIONAL(
     [HAVE_MAN_PAGES],
     [test -d "${srcdir}/man/man1" -o "x${PANDOC}" = "xyes"])
 
+AC_ARG_ENABLE([fapi],
+    [AS_HELP_STRING([--disable-fapi], [disable FAPI tools (default: auto)])],,
+    [enable_fapi=check])
+AS_IF([test "$enable_fapi" = yes -o "$enable_fapi" = check],
+      [PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi], [enable_fapi=yes], [
+         AS_IF([test "$enable_fapi" = yes], [AC_MSG_ERROR([Required module tss2-fapi not found])])
+         enable_fapi=no
+         ])
+      ])
+AM_CONDITIONAL([HAVE_FAPI], [test "$enable_fapi" = yes])
+
 PKG_CHECK_MODULES([TSS2_ESYS_3_0], [tss2-esys >= 3.0.0],
                   [AC_DEFINE([ESYS_3_0], [1], [Esys3.0])]
                   [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_3_0_CFLAGS])
@@ -76,10 +87,13 @@ AC_CANONICAL_HOST
 case "${host_os}" in
     *nto-qnx*)
         EXTRA_CFLAGS="$EXTRA_CFLAGS -D_QNX_SOURCE"
+        LIBDL_LDFLAGS=""
         ;;
     *)
+        LIBDL_LDFLAGS="-ldl"
         ;;
 esac
+AC_SUBST([LIBDL_LDFLAGS])
 
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
@@ -144,6 +158,14 @@ AS_IF([test "x$enable_unit" != xno], [
     - shasum: $SHASUM
     - mktemp: $MKTEMP"
 ])
+
+AC_ARG_ENABLE([dlclose],
+  [AS_HELP_STRING([--disable-dlclose],
+                            [Some versions of libc cause a sigsegv on exit, this disables the dlclose and works around that bug])],
+  [AC_DEFINE([DISABLE_DLCLOSE], [1],
+  [Some versions of libc cause a sigsegv on exit with dlclose(), this disables the dlclose()
+  and works around that bug])]
+ )
 
 AC_ARG_ENABLE([hardening],
   [AS_HELP_STRING([--disable-hardening],

--- a/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
@@ -1,0 +1,23 @@
+# bash completion for tss2_authorizepolicy       -*- shell-script -*-
+
+_tss2_authorizepolicy()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[pkr] | --policyPath | --keyPath  | --policyRef)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath= -p
+      --keyPath=  -k --policyRef=  -r" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_authorizepolicy tss2_authorizepolicy
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
@@ -8,14 +8,18 @@ _tss2_authorizepolicy()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pkr] | --policyPath | --keyPath  | --policyRef)
+        -!(-*)[r] | --policyRef)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[Pp] | --policyPath | --keyPath )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath= -p
-      --keyPath=  -k --policyRef=  -r" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath -P
+      --keyPath -p --policyRef -r" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_authorizepolicy tss2_authorizepolicy

--- a/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
@@ -1,0 +1,27 @@
+# bash completion for tss2_authorizepolicy       -*- shell-script -*-
+
+_tss2_authorizepolicy()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[r] | --policyRef)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[Pp] | --policyPath | --keyPath )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath -P
+      --keyPath -p --policyRef -r" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_authorizepolicy tss2_authorizepolicy
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_changeauth
+++ b/dist/bash-completion/tpm2-tools/tss2_changeauth
@@ -1,0 +1,23 @@
+# bash completion for tss2_changeauth               -*- shell-script -*-
+
+_tss2_changeauth()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ap] | --authValue | --entityPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -a --authValue
+    -p --entityPath" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_changeauth tss2_changeauth
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_changeauth
+++ b/dist/bash-completion/tpm2-tools/tss2_changeauth
@@ -8,14 +8,14 @@ _tss2_changeauth()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ae] | --authValue | --entityPath)
+        -!(-*)[ap] | --authValue | --entityPath)
             return;;
     esac
 
     $split && return
 
     COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -a --authValue
-    -e --entityPath=" -- "$cur") )
+    -p --entityPath" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_changeauth tss2_changeauth

--- a/dist/bash-completion/tpm2-tools/tss2_changeauth
+++ b/dist/bash-completion/tpm2-tools/tss2_changeauth
@@ -1,0 +1,23 @@
+# bash completion for tss2_changeauth               -*- shell-script -*-
+
+_tss2_changeauth()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ae] | --authValue | --entityPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -a --authValue
+    -e --entityPath=" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_changeauth tss2_changeauth
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_createkey
+++ b/dist/bash-completion/tpm2-tools/tss2_createkey
@@ -1,0 +1,23 @@
+# bash completion for tss2_createkey                      -*- shell-script -*-
+
+_tss2_createkey()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ptla] | --path | --type | --policyPath | --authValue)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=  -t --type=
+    -l --policyPath=  -a --authValue" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_createkey tss2_createkey
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_createkey
+++ b/dist/bash-completion/tpm2-tools/tss2_createkey
@@ -1,0 +1,23 @@
+# bash completion for tss2_createkey                      -*- shell-script -*-
+
+_tss2_createkey()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path  -t --type
+    -P --policyPath  -a --authValue" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_createkey tss2_createkey
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_createkey
+++ b/dist/bash-completion/tpm2-tools/tss2_createkey
@@ -8,14 +8,14 @@ _tss2_createkey()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ptla] | --path | --type | --policyPath | --authValue)
+        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=  -t --type=
-    -l --policyPath=  -a --authValue" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path  -t --type
+    -P --policyPath  -a --authValue" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createkey tss2_createkey

--- a/dist/bash-completion/tpm2-tools/tss2_createnv
+++ b/dist/bash-completion/tpm2-tools/tss2_createnv
@@ -1,0 +1,26 @@
+# bash completion for tss2_createnv           -*- shell-script -*-
+
+_tss2_createnv()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)t | --type)
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[psPa] | --path | --size |--policyPath | --authValue)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policy-path=
+    -p --path= -s --size= -t --type= -a --authValue" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_createnv tss2_createnv
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_createnv
+++ b/dist/bash-completion/tpm2-tools/tss2_createnv
@@ -1,0 +1,23 @@
+# bash completion for tss2_createnv           -*- shell-script -*-
+
+_tss2_createnv()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[stpPa] | --size | --type | --path | --policyPath | --authValue)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policyPath
+    -p --path -s --size -t --type -a --authValue" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_createnv tss2_createnv
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_createnv
+++ b/dist/bash-completion/tpm2-tools/tss2_createnv
@@ -8,17 +8,14 @@ _tss2_createnv()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)t | --type)
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)[psPa] | --path | --size |--policyPath | --authValue)
+        -!(-*)[stpPa] | --size | --type | --path | --policyPath | --authValue)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policy-path=
-    -p --path= -s --size= -t --type= -a --authValue" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policyPath
+    -p --path -s --size -t --type -a --authValue" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createnv tss2_createnv

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -1,0 +1,26 @@
+# bash completion for tss2_createseal                      -*- shell-script -*-
+
+_tss2_createseal()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[i] | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue -a --path -p --policyPath -P --type -t --data -i" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_createseal tss2_createseal
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -8,13 +8,17 @@ _tss2_createseal()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ptPad] | --path | --type | --policyPath | --authValue | --data)
+        -!(-*)[i] | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --password -a --path= -p --policyPath= -P --type= -t --data= -d" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue -a --path -p --policyPath -P --type -t --data -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createseal tss2_createseal

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -1,0 +1,22 @@
+# bash completion for tss2_createseal                      -*- shell-script -*-
+
+_tss2_createseal()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ptPad] | --path | --type | --policyPath | --authValue | --data)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --password -a --path= -p --policyPath= -P --type= -t --data= -d" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_createseal tss2_createseal
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_decrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_decrypt
@@ -1,0 +1,24 @@
+# bash completion for tss2_decrypt -*- shell-script -*-
+
+_tss2_decrypt()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[kpc] | --keyPath | --plainText | --cipherText)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -c --cipherText= --plainText= -p --keyPath= -k" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_decrypt tss2_decrypt
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_decrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_decrypt
@@ -1,0 +1,26 @@
+# bash completion for tss2_decrypt -*- shell-script -*-
+
+_tss2_decrypt()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[io] | --cipherText | --plainText)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --keyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -i --cipherText --plainText -o --keyPath -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_decrypt tss2_decrypt
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_decrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_decrypt
@@ -8,15 +8,17 @@ _tss2_decrypt()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[kpc] | --keyPath | --plainText | --cipherText)
+        -!(-*)[io] | --cipherText | --plainText)
             _filedir
             COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --keyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -c --cipherText= --plainText= -p --keyPath= -k" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -i --cipherText --plainText -o --keyPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_decrypt tss2_decrypt

--- a/dist/bash-completion/tpm2-tools/tss2_delete
+++ b/dist/bash-completion/tpm2-tools/tss2_delete
@@ -9,13 +9,12 @@ _tss2_delete()
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
         -!(-*)p | --path)
-            COMPREPLY=( $(compgen -W "$(tss2_list --path=$cur)" -- $cur))
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_delete tss2_delete

--- a/dist/bash-completion/tpm2-tools/tss2_delete
+++ b/dist/bash-completion/tpm2-tools/tss2_delete
@@ -1,0 +1,22 @@
+# bash completion for tss2_delete                   -*- shell-script -*-
+
+_tss2_delete()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_delete tss2_delete
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_delete
+++ b/dist/bash-completion/tpm2-tools/tss2_delete
@@ -1,0 +1,23 @@
+# bash completion for tss2_delete                   -*- shell-script -*-
+
+_tss2_delete()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)p | --path)
+            COMPREPLY=( $(compgen -W "$(tss2_list --path=$cur)" -- $cur))
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_delete tss2_delete
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -1,0 +1,27 @@
+# bash completion for tss2_encrypt                    -*- shell-script -*-
+
+_tss2_encrypt()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[cP] | --cipherText | --plainText)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[kp] | --keyPath | --policyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --cipherText= -c
+    --keyPath= k --policyPath= -p --plainText= -P" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_encrypt tss2_encrypt
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -8,18 +8,18 @@ _tss2_encrypt()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[cP] | --cipherText | --plainText)
+        -!(-*)[io] | --plainText | --cipherText)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[kp] | --keyPath | --policyPath)
+        -!(-*)[pP] | --keyPath | --policyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --cipherText= -c
-    --keyPath= k --policyPath= -p --plainText= -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -o --cipherText
+    -p --keyPath  -P --policyPath -i --plainText" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_encrypt tss2_encrypt

--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -1,0 +1,27 @@
+# bash completion for tss2_encrypt                    -*- shell-script -*-
+
+_tss2_encrypt()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[io] | --plainText | --cipherText)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[pP] | --keyPath | --policyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -o --cipherText
+    -p --keyPath  -P --policyPath -i --plainText" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_encrypt tss2_encrypt
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_exportkey
+++ b/dist/bash-completion/tpm2-tools/tss2_exportkey
@@ -1,0 +1,26 @@
+# bash completion for tss2_exportkey                  -*- shell-script -*-
+
+_tss2_exportkey()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[o] | --exportedData )
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[pe] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData -o --force -f --pathOfKeyToDuplicate -p --pathToPublicKeyOfNewParent -e" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_exportkey tss2_exportkey
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_exportkey
+++ b/dist/bash-completion/tpm2-tools/tss2_exportkey
@@ -8,17 +8,17 @@ _tss2_exportkey()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)e | --exportedData)
+        -!(-*)[o] | --exportedData )
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[pP] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
+        -!(-*)[pe] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData= -e --force -f --pathOfKeyToDuplicate= -p --pathToPublicKeyOfNewParent= -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData -o --force -f --pathOfKeyToDuplicate -p --pathToPublicKeyOfNewParent -e" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_exportkey tss2_exportkey

--- a/dist/bash-completion/tpm2-tools/tss2_exportkey
+++ b/dist/bash-completion/tpm2-tools/tss2_exportkey
@@ -1,0 +1,26 @@
+# bash completion for tss2_exportkey                  -*- shell-script -*-
+
+_tss2_exportkey()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)e | --exportedData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[pP] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData= -e --force -f --pathOfKeyToDuplicate= -p --pathToPublicKeyOfNewParent= -P" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_exportkey tss2_exportkey
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_exportpolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_exportpolicy
@@ -8,18 +8,18 @@ _tss2_exportpolicy()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)j | --jsonPolicy)
+        -!(-*)[o] | --jsonPolicy )
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)p | --path)
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy= -j
-    --path= -p --force= -f" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy -o
+    --path -p --force -f" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_exportpolicy tss2_exportpolicy

--- a/dist/bash-completion/tpm2-tools/tss2_exportpolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_exportpolicy
@@ -1,0 +1,27 @@
+# bash completion for tss2_exportpolicy                    -*- shell-script -*-
+
+_tss2_exportpolicy()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[o] | --jsonPolicy )
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[p] | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy -o
+    --path -p --force -f" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_exportpolicy tss2_exportpolicy
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_exportpolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_exportpolicy
@@ -1,0 +1,27 @@
+# bash completion for tss2_exportpolicy                    -*- shell-script -*-
+
+_tss2_exportpolicy()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)j | --jsonPolicy)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy= -j
+    --path= -p --force= -f" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_exportpolicy tss2_exportpolicy
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_getappdata
@@ -1,0 +1,26 @@
+# bash completion for tss2_getappdata              -*- shell-script -*-
+
+_tss2_getappdata()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)a | --appData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -a" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getappdata tss2_getappdata
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_getappdata
@@ -8,17 +8,17 @@ _tss2_getappdata()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)a | --appData)
+        -!(-*)[o] | --appData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)p | --path)
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -a" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getappdata tss2_getappdata

--- a/dist/bash-completion/tpm2-tools/tss2_getappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_getappdata
@@ -1,0 +1,26 @@
+# bash completion for tss2_getappdata              -*- shell-script -*-
+
+_tss2_getappdata()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[o] | --appData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[p] | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -o" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getappdata tss2_getappdata
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_getcertificate
@@ -8,17 +8,17 @@ _tss2_getcertificate()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)x | --x509certData)
+        -!(-*)[o] | --x509certData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)p | --path)
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --x509certData= -x" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --x509certData -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getcertificate tss2_getcertificate

--- a/dist/bash-completion/tpm2-tools/tss2_getcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_getcertificate
@@ -1,0 +1,26 @@
+# bash completion for tss2_getcertificate              -*- shell-script -*-
+
+_tss2_getcertificate()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)x | --x509certData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --x509certData= -x" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getcertificate tss2_getcertificate
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_getcertificate
@@ -1,0 +1,26 @@
+# bash completion for tss2_getcertificate              -*- shell-script -*-
+
+_tss2_getcertificate()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[o] | --x509certData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[p] | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --x509certData -o" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getcertificate tss2_getcertificate
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -1,0 +1,23 @@
+# bash completion for tss2_getdescription -*- shell-script -*-
+
+_tss2_getdescription()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[pd] | --path | --description)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p
+    --description= -d " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getdescription tss2_getdescription
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -8,14 +8,18 @@ _tss2_getdescription()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pd] | --path | --description)
+        -!(-*)[o] | --description)
+            COMPREPLY+=( '-' )
+            _filedir
+            return;;
+        -!(-*)[p] | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p
-    --description= -d " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p
+    --description -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getdescription tss2_getdescription

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -1,0 +1,27 @@
+# bash completion for tss2_getdescription -*- shell-script -*-
+
+_tss2_getdescription()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[o] | --description)
+            COMPREPLY+=( '-' )
+            _filedir
+            return;;
+        -!(-*)[p] | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p
+    --description -o " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getdescription tss2_getdescription
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getinfo
+++ b/dist/bash-completion/tpm2-tools/tss2_getinfo
@@ -1,0 +1,24 @@
+# bash completion for tss2_getinfo                      -*- shell-script -*-
+
+_tss2_getinfo()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)o | --info)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info -o" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getinfo tss2_getinfo
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getinfo
+++ b/dist/bash-completion/tpm2-tools/tss2_getinfo
@@ -1,0 +1,24 @@
+# bash completion for tss2_getinfo                      -*- shell-script -*-
+
+_tss2_getinfo()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)i | --info)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info= -i" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getinfo tss2_getinfo
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getinfo
+++ b/dist/bash-completion/tpm2-tools/tss2_getinfo
@@ -8,7 +8,7 @@ _tss2_getinfo()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)i | --info)
+        -!(-*)o | --info)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -16,7 +16,7 @@ _tss2_getinfo()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info= -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getinfo tss2_getinfo

--- a/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
+++ b/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
@@ -1,0 +1,24 @@
+# bash completion for tss2_getplatformcertificates              -*- shell-script -*-
+
+_tss2_getplatformcertificates()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)o | --certificates)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates -o" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getplatformcertificates tss2_getplatformcertificates
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
+++ b/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
@@ -1,0 +1,24 @@
+# bash completion for tss2_getplatformcertificates              -*- shell-script -*-
+
+_tss2_getplatformcertificates()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)c | --certificates)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates= -c" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getplatformcertificates tss2_getplatformcertificates
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
+++ b/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
@@ -8,7 +8,7 @@ _tss2_getplatformcertificates()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)c | --certificates)
+        -!(-*)o | --certificates)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -16,7 +16,7 @@ _tss2_getplatformcertificates()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates= -c" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getplatformcertificates tss2_getplatformcertificates

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -1,0 +1,26 @@
+# bash completion for tss2_getrandom                   -*- shell-script -*-
+
+_tss2_getrandom()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)d | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)n | --numBytes)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes= --data= -d -n" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getrandom tss2_getrandom
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -1,0 +1,26 @@
+# bash completion for tss2_getrandom                   -*- shell-script -*-
+
+_tss2_getrandom()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)o | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)n | --numBytes)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes -n --data -o " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_getrandom tss2_getrandom
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -8,7 +8,7 @@ _tss2_getrandom()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)o | --data)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_getrandom()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes= --data= -d -n" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes -n --data -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getrandom tss2_getrandom

--- a/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
@@ -1,0 +1,36 @@
+# bash completion for tss2_gettpmblobs              -*- shell-script -*-
+
+_tss2_gettpmblobs()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)p | --path)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)u | --tpm2bPublic
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)r | --tpm2bPrivate
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)l | --policy
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path= -p --tpm2bPublic= -u --tpm2bPrivate= -r --policy= -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_gettpmblobs tss2_gettpmblobs
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
@@ -8,19 +8,9 @@ _tss2_gettpmblobs()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)p | --path)
-            _filedir
-            COMPREPLY+=( '-' )
+        -!(-*)[p] | --path )
             return;;
-        -!(-*)u | --tpm2bPublic
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)r | --tpm2bPrivate
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)l | --policy
+        -!(-*)[url] | --tpm2bPublic | --tpm2bPrivate | --policy)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -28,7 +18,7 @@ _tss2_gettpmblobs()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path= -p --tpm2bPublic= -u --tpm2bPrivate= -r --policy= -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path -p --tpm2bPublic -u --tpm2bPrivate -r --policy -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_gettpmblobs tss2_gettpmblobs

--- a/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
@@ -1,0 +1,26 @@
+# bash completion for tss2_gettpmblobs              -*- shell-script -*-
+
+_tss2_gettpmblobs()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[p] | --path )
+            return;;
+        -!(-*)[url] | --tpm2bPublic | --tpm2bPrivate | --policy)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path -p --tpm2bPublic -u --tpm2bPrivate -r --policy -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_gettpmblobs tss2_gettpmblobs
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_import
+++ b/dist/bash-completion/tpm2-tools/tss2_import
@@ -1,0 +1,26 @@
+# bash completion for tss2_import                   -*- shell-script -*-
+
+_tss2_import()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)d | --importData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --importData= -d --path= -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_import tss2_import
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_import
+++ b/dist/bash-completion/tpm2-tools/tss2_import
@@ -1,0 +1,26 @@
+# bash completion for tss2_import                   -*- shell-script -*-
+
+_tss2_import()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[p] | --path)
+            return;;
+        -!(-*)[i] | --importData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --importData -i --path -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_import tss2_import
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_import
+++ b/dist/bash-completion/tpm2-tools/tss2_import
@@ -8,17 +8,17 @@ _tss2_import()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --importData)
+        -!(-*)[p] | --path)
+            return;;
+        -!(-*)[i] | --importData)
             _filedir
             COMPREPLY+=( '-' )
-            return;;
-        -!(-*)p | --path)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --importData= -d --path= -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --importData -i --path -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_import tss2_import

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -8,14 +8,18 @@ _tss2_list()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ps] | --pathList | searchPath )
+        -!(-*)[p] | --searchPath)
+            return;;
+        -!(-*)[o] | --pathList)
+            _filedir
+            COMPREPLY+=( '-' )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -p
-    --searchPath -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -o
+    --searchPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_list tss2_list

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -1,0 +1,23 @@
+# bash completion for tss2_list                   -*- shell-script -*-
+
+_tss2_list()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ps] | --pathList | searchPath )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -p
+    --searchPath -s" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_list tss2_list
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -1,0 +1,27 @@
+# bash completion for tss2_list                   -*- shell-script -*-
+
+_tss2_list()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[p] | --searchPath)
+            return;;
+        -!(-*)[o] | --pathList)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -o
+    --searchPath -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_list tss2_list
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvextend
+++ b/dist/bash-completion/tpm2-tools/tss2_nvextend
@@ -8,17 +8,17 @@ _tss2_nvextend()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)[il] | --data |  --logData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[nl] | --nvPath | --logData)
+        -!(-*)[p] | --nvPath )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --policy-path= --data= --nvPath= --logData= -d -n -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -i --nvPath -p --logData -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvextend tss2_nvextend

--- a/dist/bash-completion/tpm2-tools/tss2_nvextend
+++ b/dist/bash-completion/tpm2-tools/tss2_nvextend
@@ -1,0 +1,26 @@
+# bash completion for tss2_nvextend                       -*- shell-script -*-
+
+_tss2_nvextend()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)d | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[nl] | --nvPath | --logData)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --policy-path= --data= --nvPath= --logData= -d -n -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvextend tss2_nvextend
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvextend
+++ b/dist/bash-completion/tpm2-tools/tss2_nvextend
@@ -1,0 +1,26 @@
+# bash completion for tss2_nvextend                       -*- shell-script -*-
+
+_tss2_nvextend()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[il] | --data |  --logData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[p] | --nvPath )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -i --nvPath -p --logData -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvextend tss2_nvextend
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvincrement
+++ b/dist/bash-completion/tpm2-tools/tss2_nvincrement
@@ -1,0 +1,22 @@
+# bash completion for tss2_nvincremend                    -*- shell-script -*-
+
+_tss2_nvincrement()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)p | --nvPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvincrement tss2_nvincrement
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvincrement
+++ b/dist/bash-completion/tpm2-tools/tss2_nvincrement
@@ -1,0 +1,22 @@
+# bash completion for tss2_nvincremend                    -*- shell-script -*-
+
+_tss2_nvincrement()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)n | --nvPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -n" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvincrement tss2_nvincrement
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvincrement
+++ b/dist/bash-completion/tpm2-tools/tss2_nvincrement
@@ -8,13 +8,13 @@ _tss2_nvincrement()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)n | --nvPath)
+        -!(-*)p | --nvPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -n" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvincrement tss2_nvincrement

--- a/dist/bash-completion/tpm2-tools/tss2_nvread
+++ b/dist/bash-completion/tpm2-tools/tss2_nvread
@@ -1,0 +1,26 @@
+# bash completion for tss2_nvread                         -*- shell-script -*-
+
+_tss2_nvread()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)d | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[nl] | --nvPath | --logData)
+            return
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath= -n --data= -d --logData= -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvread tss2_nvread
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvread
+++ b/dist/bash-completion/tpm2-tools/tss2_nvread
@@ -8,17 +8,17 @@ _tss2_nvread()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)[p] | --nvPath)
+            return;;
+        -!(-*)[ol] | --data | --logData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[nl] | --nvPath | --logData)
-            return
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath= -n --data= -d --logData= -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath -p --data -o --logData -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvread tss2_nvread

--- a/dist/bash-completion/tpm2-tools/tss2_nvread
+++ b/dist/bash-completion/tpm2-tools/tss2_nvread
@@ -1,0 +1,26 @@
+# bash completion for tss2_nvread                         -*- shell-script -*-
+
+_tss2_nvread()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[p] | --nvPath)
+            return;;
+        -!(-*)[ol] | --data | --logData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath -p --data -o --logData -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvread tss2_nvread
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvsetbits
+++ b/dist/bash-completion/tpm2-tools/tss2_nvsetbits
@@ -1,0 +1,22 @@
+# bash completion for tss2_nvsetbits                      -*- shell-script -*-
+
+_tss2_nvsetbits()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[bn] | --bitmap | --nvPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -b --bitmap= --nvPath= -n" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvsetbits tss2_nvsetbits
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvsetbits
+++ b/dist/bash-completion/tpm2-tools/tss2_nvsetbits
@@ -8,13 +8,13 @@ _tss2_nvsetbits()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[bn] | --bitmap | --nvPath)
+        -!(-*)[ip] | --bitmap | --nvPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -b --bitmap= --nvPath= -n" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -i --bitmap -p --nvPath" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvsetbits tss2_nvsetbits

--- a/dist/bash-completion/tpm2-tools/tss2_nvsetbits
+++ b/dist/bash-completion/tpm2-tools/tss2_nvsetbits
@@ -1,0 +1,22 @@
+# bash completion for tss2_nvsetbits                      -*- shell-script -*-
+
+_tss2_nvsetbits()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ip] | --bitmap | --nvPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -i --bitmap -p --nvPath" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvsetbits tss2_nvsetbits
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvwrite
+++ b/dist/bash-completion/tpm2-tools/tss2_nvwrite
@@ -8,17 +8,17 @@ _tss2_nvwrite()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)[p] | --nvPath)
+            return;;
+        -!(-*)[i] | --data)
             _filedir
             COMPREPLY+=( '-' )
-            return;;
-        -!(-*)[n] | --nvPath )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= --data= -n -d" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p --data  -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvwrite tss2_nvwrite

--- a/dist/bash-completion/tpm2-tools/tss2_nvwrite
+++ b/dist/bash-completion/tpm2-tools/tss2_nvwrite
@@ -1,0 +1,26 @@
+# bash completion for tss2_nvwrite                        -*- shell-script -*-
+
+_tss2_nvwrite()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)d | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[n] | --nvPath )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= --data= -n -d" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvwrite tss2_nvwrite
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_nvwrite
+++ b/dist/bash-completion/tpm2-tools/tss2_nvwrite
@@ -1,0 +1,26 @@
+# bash completion for tss2_nvwrite                        -*- shell-script -*-
+
+_tss2_nvwrite()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[p] | --nvPath)
+            return;;
+        -!(-*)[i] | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p --data  -i" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_nvwrite tss2_nvwrite
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -1,0 +1,22 @@
+# bash completion for tss2_pcrextend                      -*- shell-script -*-
+
+_tss2_pcrextend()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[cdl] | --pcr | --data | --logData)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -c -d --pcr --data --logData -l -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_pcrextend tss2_pcrextend
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -1,0 +1,26 @@
+# bash completion for tss2_pcrextend                      -*- shell-script -*-
+
+_tss2_pcrextend()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[x] | --pcr)
+            return;;
+        -!(-*)[il] | --data | --logData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr -i --data -l --logData -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_pcrextend tss2_pcrextend
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -8,13 +8,17 @@ _tss2_pcrextend()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[cdl] | --pcr | --data | --logData)
+        -!(-*)[x] | --pcr)
+            return;;
+        -!(-*)[il] | --data | --logData)
+            _filedir
+            COMPREPLY+=( '-' )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -c -d --pcr --data --logData -l -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr -i --data -l --logData -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrextend tss2_pcrextend

--- a/dist/bash-completion/tpm2-tools/tss2_pcrread
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrread
@@ -8,9 +8,9 @@ _tss2_pcrread()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)i | --pcrIndex)
+        -!(-*)[x] | --pcrIndex)
             return;;
-        -!(-*)[cl] | --pcrValue | --pcrLog)
+        -!(-*)[ol] | --pcrValue | --pcrLog)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_pcrread()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrValue= --pcrIndex= --force -f --pcrLog= -c -i -f -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -o --pcrValue -x --pcrIndex --force -f -l --pcrLog" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrread tss2_pcrread

--- a/dist/bash-completion/tpm2-tools/tss2_pcrread
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrread
@@ -1,0 +1,26 @@
+# bash completion for tss2_pcrread                 -*- shell-script -*-
+
+_tss2_pcrread()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[x] | --pcrIndex)
+            return;;
+        -!(-*)[ol] | --pcrValue | --pcrLog)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -o --pcrValue -x --pcrIndex --force -f -l --pcrLog" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_pcrread tss2_pcrread
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_pcrread
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrread
@@ -1,0 +1,26 @@
+# bash completion for tss2_pcrread                 -*- shell-script -*-
+
+_tss2_pcrread()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)i | --pcrIndex)
+            return;;
+        -!(-*)[cl] | --pcrValue | --pcrLog)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrValue= --pcrIndex= --force -f --pcrLog= -c -i -f -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_pcrread tss2_pcrread
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_provision
+++ b/dist/bash-completion/tpm2-tools/tss2_provision
@@ -1,0 +1,22 @@
+# bash completion for tss2_provision                       -*- shell-script -*-
+
+_tss2_provision()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ESL] | --authValueEh | --authValueSh | --authValueLockout )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -E -S -L --authValueEh --authValueSh --authValueLockout" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_provision tss2_provision
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_provision
+++ b/dist/bash-completion/tpm2-tools/tss2_provision
@@ -1,0 +1,22 @@
+# bash completion for tss2_provision                       -*- shell-script -*-
+
+_tss2_provision()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[esl] | --authValueEh | --authValueSh | --authValueLockout )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -e -s -l --authValueEh --authValueSh --authValueLockout" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_provision tss2_provision
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_provision
+++ b/dist/bash-completion/tpm2-tools/tss2_provision
@@ -8,13 +8,13 @@ _tss2_provision()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[esl] | --authValueEh | --authValueSh | --authValueLockout )
+        -!(-*)[ESL] | --authValueEh | --authValueSh | --authValueLockout )
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -e -s -l --authValueEh --authValueSh --authValueLockout" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -E -S -L --authValueEh --authValueSh --authValueLockout" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_provision tss2_provision

--- a/dist/bash-completion/tpm2-tools/tss2_quote
+++ b/dist/bash-completion/tpm2-tools/tss2_quote
@@ -1,0 +1,26 @@
+# bash completion for tss2_quote                       -*- shell-script -*-
+
+_tss2_quote()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[slqdc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[Lk] | --pcrList | --keyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -L -l -d -s -f -k -d -q -c --pcrList= --qualifyingData= --pcrLog= --force --path= --quoteInfo= --signature= --certificate= " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_quote tss2_quote
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_quote
+++ b/dist/bash-completion/tpm2-tools/tss2_quote
@@ -1,0 +1,26 @@
+# bash completion for tss2_quote                       -*- shell-script -*-
+
+_tss2_quote()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[px] | --keyPath | --pcrList)
+            return;;
+        -!(-*)[olqQc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrList -x --qualifyingData -Q --pcrLog -l --force -f --keyPath -p --quoteInfo -q --signature -o --certificate -c " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_quote tss2_quote
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_quote
+++ b/dist/bash-completion/tpm2-tools/tss2_quote
@@ -8,17 +8,17 @@ _tss2_quote()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[slqdc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
+        -!(-*)[px] | --keyPath | --pcrList)
+            return;;
+        -!(-*)[olqQc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
             _filedir
             COMPREPLY+=( '-' )
-            return;;
-        -!(-*)[Lk] | --pcrList | --keyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -L -l -d -s -f -k -d -q -c --pcrList= --qualifyingData= --pcrLog= --force --path= --quoteInfo= --signature= --certificate= " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrList -x --qualifyingData -Q --pcrLog -l --force -f --keyPath -p --quoteInfo -q --signature -o --certificate -c " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_quote tss2_quote

--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -1,0 +1,23 @@
+# bash completion for tss2_setappdata              -*- shell-script -*-
+
+_tss2_setappdata()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[pi] | --path | --appData)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -i" -- "$cur") )
+
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_setappdata tss2_setappdata
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -8,17 +8,13 @@ _tss2_setappdata()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)a | --appData)
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)p | --path)
+        -!(-*)[pi] | --path | --appData)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -a" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -i" -- "$cur") )
 
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -1,0 +1,27 @@
+# bash completion for tss2_setappdata              -*- shell-script -*-
+
+_tss2_setappdata()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)a | --appData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -a" -- "$cur") )
+
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_setappdata tss2_setappdata
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_setcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_setcertificate
@@ -8,7 +8,7 @@ _tss2_setcertificate()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)x | --x509certData)
+        -!(-*)i | --x509certData)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_setcertificate()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path= --x509certData= -x" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path --x509certData -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_setcertificate tss2_setcertificate

--- a/dist/bash-completion/tpm2-tools/tss2_setcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_setcertificate
@@ -1,0 +1,26 @@
+# bash completion for tss2_setcertificate              -*- shell-script -*-
+
+_tss2_setcertificate()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)x | --x509certData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path= --x509certData= -x" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_setcertificate tss2_setcertificate
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_setcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_setcertificate
@@ -1,0 +1,26 @@
+# bash completion for tss2_setcertificate              -*- shell-script -*-
+
+_tss2_setcertificate()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)i | --x509certData)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path --x509certData -i" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_setcertificate tss2_setcertificate
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_setdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_setdescription
@@ -1,0 +1,22 @@
+# bash completion for tss2_setdescription -*- shell-script -*-
+
+_tss2_setdescription()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[pd] | --path | --description)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p --description -d " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_setdescription tss2_setdescription
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_setdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_setdescription
@@ -1,0 +1,22 @@
+# bash completion for tss2_setdescription -*- shell-script -*-
+
+_tss2_setdescription()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[pi] | --path | --description)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p --description -i " -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_setdescription tss2_setdescription
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_setdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_setdescription
@@ -8,13 +8,13 @@ _tss2_setdescription()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pd] | --path | --description)
+        -!(-*)[pi] | --path | --description)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p --description -d " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p --description -i " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_setdescription tss2_setdescription

--- a/dist/bash-completion/tpm2-tools/tss2_sign
+++ b/dist/bash-completion/tpm2-tools/tss2_sign
@@ -8,17 +8,17 @@ _tss2_sign()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[dspcP] | --digest | --signature | --publicKey | --certificate | --padding)
+        -!(-*)[dokc] | --digest | --signature | --publicKey | --certificate)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)k | --keyPath)
+        -!(-*)[ps] | --keyPath | --padding)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate= -c --digest= -d --keyPath= -k --publicKey= -p --signature= -s --padding -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate -c --digest -d --keyPath -p --publicKey -k --signature -o --padding -s" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_sign tss2_sign

--- a/dist/bash-completion/tpm2-tools/tss2_sign
+++ b/dist/bash-completion/tpm2-tools/tss2_sign
@@ -1,0 +1,26 @@
+# bash completion for tss2_sign                        -*- shell-script -*-
+
+_tss2_sign()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[dokc] | --digest | --signature | --publicKey | --certificate)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[ps] | --keyPath | --padding)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate -c --digest -d --keyPath -p --publicKey -k --signature -o --padding -s" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_sign tss2_sign
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_sign
+++ b/dist/bash-completion/tpm2-tools/tss2_sign
@@ -1,0 +1,26 @@
+# bash completion for tss2_sign                        -*- shell-script -*-
+
+_tss2_sign()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[dspcP] | --digest | --signature | --publicKey | --certificate | --padding)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)k | --keyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate= -c --digest= -d --keyPath= -k --publicKey= -p --signature= -s --padding -P" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_sign tss2_sign
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -1,0 +1,26 @@
+# bash completion for tss2_unseal                        -*- shell-script -*-
+
+_tss2_unseal()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)o | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -o --path -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_unseal tss2_unseal
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -8,7 +8,7 @@ _tss2_unseal()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)d | --data)
+        -!(-*)o | --data)
             _filedir
             COMPREPLY+=( '-' )
             return;;
@@ -18,7 +18,7 @@ _tss2_unseal()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --data= -d --path= -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -o --path -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_unseal tss2_unseal

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -1,0 +1,26 @@
+# bash completion for tss2_unseal                        -*- shell-script -*-
+
+_tss2_unseal()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)d | --data)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --path )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data= -d --path= -p" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_unseal tss2_unseal
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_verifyquote
+++ b/dist/bash-completion/tpm2-tools/tss2_verifyquote
@@ -1,0 +1,26 @@
+# bash completion for tss2_verifyquote                 -*- shell-script -*-
+
+_tss2_verifyquote()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[qs] | --qualifyingData | --signature)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[lip] | --pcrLog | --quoteInfo | --publicKeyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData= -q --pcrLog= -l --quoteInfo= -i --publicKeyPath= -p --signature= -s" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_verifyquote tss2_verifyquote
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_verifyquote
+++ b/dist/bash-completion/tpm2-tools/tss2_verifyquote
@@ -8,17 +8,17 @@ _tss2_verifyquote()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[qs] | --qualifyingData | --signature)
+        -!(-*)[Qilq] | --qualifyingData | --signature | --pcrLog | --quoteInfo)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[lip] | --pcrLog | --quoteInfo | --publicKeyPath)
+        -!(-*)[k] | --publicKeyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData= -q --pcrLog= -l --quoteInfo= -i --publicKeyPath= -p --signature= -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData -Q --pcrLog -l --quoteInfo -q --publicKeyPath -k --signature -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_verifyquote tss2_verifyquote

--- a/dist/bash-completion/tpm2-tools/tss2_verifyquote
+++ b/dist/bash-completion/tpm2-tools/tss2_verifyquote
@@ -1,0 +1,26 @@
+# bash completion for tss2_verifyquote                 -*- shell-script -*-
+
+_tss2_verifyquote()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[Qilq] | --qualifyingData | --signature | --pcrLog | --quoteInfo)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)[k] | --publicKeyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData -Q --pcrLog -l --quoteInfo -q --publicKeyPath -k --signature -i" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_verifyquote tss2_verifyquote
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -1,0 +1,26 @@
+# bash completion for tss2_verifysignature             -*- shell-script -*-
+
+_tss2_verifysignature()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[di] | --digest | --signature)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)p | --keyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --digest -d --keyPath -p --signature -i" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2verify_signature tss2verify_signature
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -1,0 +1,26 @@
+# bash completion for tss2_verifysignature             -*- shell-script -*-
+
+_tss2_verifysignature()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[ds] | --digest | --signature)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)k | --keyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --digest= -d --keyPath= -k --signature= -s" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2verify_signature tss2verify_signature
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -8,17 +8,17 @@ _tss2_verifysignature()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[ds] | --digest | --signature)
+        -!(-*)[di] | --digest | --signature)
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)k | --keyPath)
+        -!(-*)p | --keyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --digest= -d --keyPath= -k --signature= -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --digest -d --keyPath -p --signature -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2verify_signature tss2verify_signature

--- a/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
+++ b/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
@@ -8,19 +8,13 @@ _tss2_writeauthorizenv()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)n | --nvPath)
-            _filedir
-            COMPREPLY+=( '-' )
-            return;;
-        -!(-*)l | --policyPath )
-            _filedir
-            COMPREPLY+=( '-' )
+        -!(-*)[pP] | --nvPath | --policyPath)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -n -policyPath= -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p -policyPath -P" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_writeauthorizenv tss2_writeauthorizenv

--- a/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
+++ b/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
@@ -1,0 +1,28 @@
+# bash completion for tss2_writeauthorizenv                        -*- shell-script -*-
+
+_tss2_writeauthorizenv()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)n | --nvPath)
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+        -!(-*)l | --policyPath )
+            _filedir
+            COMPREPLY+=( '-' )
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -n -policyPath= -l" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_writeauthorizenv tss2_writeauthorizenv
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
+++ b/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
@@ -1,0 +1,22 @@
+# bash completion for tss2_writeauthorizenv                        -*- shell-script -*-
+
+_tss2_writeauthorizenv()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[pP] | --nvPath | --policyPath)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p -policyPath -P" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_writeauthorizenv tss2_writeauthorizenv
+
+# ex: filetype=sh

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -301,6 +301,9 @@ static alg_parser_rc handle_rsa(const char *ext, TPM2B_PUBLIC *public) {
     } else if (!strncmp(ext, "4096", 4)) {
         r->keyBits = 4096;
         ext += 4;
+    } else if (!strncmp(ext, "3072", 4)) {
+        r->keyBits = 3072;
+        ext += 4;
     } else {
         r->keyBits = 2048;
     }

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -588,6 +588,7 @@ bool tpm2_policy_parse_policy_list(char *str, TPML_DIGEST *policy_list) {
                 hash = tpm2_alg_util_from_optarg(subtoken,
                         tpm2_alg_util_flags_hash);
                 if (hash == TPM2_ALG_ERROR) {
+                    LOG_ERR("Invalid/ Unspecified policy digest algorithm.");
                     return false;
                 }
             }

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -17,6 +17,142 @@
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
+bool tpm2_util_get_digest_from_quote(TPM2B_ATTEST *quoted, TPM2B_DIGEST *digest,
+        TPM2B_DATA *extra_data) {
+    TPM2_GENERATED magic;
+    TPMI_ST_ATTEST type;
+    UINT16 name_size = 0;
+    UINT32 i = 0;
+
+    // Ensure required headers are at least there
+    if (quoted->size < 6) {
+        LOG_ERR("Malformed TPM2B_ATTEST headers");
+        return false;
+    }
+
+    memcpy(&magic, &quoted->attestationData[i], 4);
+    i += 4;
+    memcpy(&type, &quoted->attestationData[i], 2);
+    i += 2;
+    if (!tpm2_util_is_big_endian()) {
+        magic = tpm2_util_endian_swap_32(magic);
+        type = tpm2_util_endian_swap_16(type);
+    }
+
+    if (magic != TPM2_GENERATED_VALUE) {
+        LOG_ERR("Malformed TPM2_GENERATED magic value");
+        return false;
+    }
+
+    if (type != TPM2_ST_ATTEST_QUOTE) {
+        LOG_ERR("Malformed TPMI_ST_ATTEST quote value");
+        return false;
+    }
+
+    // Qualified signer name (skip)
+    if (i + 2 >= quoted->size) {
+        LOG_ERR("Malformed TPM2B_NAME value");
+        return false;
+    }
+    memcpy(&name_size, &quoted->attestationData[i], 2);
+    i += 2;
+    if (!tpm2_util_is_big_endian()) {
+        name_size = tpm2_util_endian_swap_16(name_size);
+    }
+    i += name_size;
+
+    // Extra data (skip)
+    if (i + 2 >= quoted->size) {
+        LOG_ERR("Malformed TPM2B_DATA value");
+        return false;
+    }
+    memcpy(&extra_data->size, &quoted->attestationData[i], 2);
+    i += 2;
+    if (!tpm2_util_is_big_endian()) {
+        extra_data->size = tpm2_util_endian_swap_16(extra_data->size);
+    }
+    if (extra_data->size + i > quoted->size) {
+        LOG_ERR("Malformed extra_data TPM2B_DATA value");
+        return false;
+    }
+    memcpy(&extra_data->buffer, &quoted->attestationData[i], extra_data->size);
+    i += extra_data->size;
+
+    // Clock info (skip)
+    i += 17;
+    if (i >= quoted->size) {
+        LOG_ERR("Malformed TPMS_CLOCK_INFO value");
+        return false;
+    }
+
+    // Firmware info (skip)
+    i += 8;
+    if (i >= quoted->size) {
+        LOG_ERR("Malformed firmware version value");
+        return false;
+    }
+
+    // PCR select info
+    UINT8 sos;
+    TPMI_ALG_HASH hash_alg;
+    UINT32 pcr_select_count = 0, j = 0;
+    if (i + 4 >= quoted->size) {
+        LOG_ERR("Malformed TPML_PCR_SELECTION value");
+        return false;
+    }
+    memcpy(&pcr_select_count, &quoted->attestationData[i], 4);
+    i += 4;
+    if (!tpm2_util_is_big_endian()) {
+        pcr_select_count = tpm2_util_endian_swap_32(pcr_select_count);
+    }
+    for (j = 0; j < pcr_select_count; j++) {
+        // Hash
+        if (i + 2 >= quoted->size) {
+            LOG_ERR("Malformed TPMS_PCR_SELECTION value");
+            return false;
+        }
+        memcpy(&hash_alg, &quoted->attestationData[i], 2);
+        i += 2;
+        if (!tpm2_util_is_big_endian()) {
+            hash_alg = tpm2_util_endian_swap_16(hash_alg);
+        }
+
+        // SizeOfSelected
+        if (i + 1 >= quoted->size) {
+            LOG_ERR("Malformed TPMS_PCR_SELECTION value");
+            return false;
+        }
+        memcpy(&sos, &quoted->attestationData[i], 1);
+        i += 1;
+
+        // PCR Select (skip)
+        i += sos;
+        if (i >= quoted->size) {
+            LOG_ERR("Malformed TPMS_PCR_SELECTION value");
+            return false;
+        }
+    }
+
+    // Digest
+    if (i + 2 >= quoted->size) {
+        LOG_ERR("Malformed TPM2B_DIGEST value");
+        return false;
+    }
+    memcpy(&digest->size, &quoted->attestationData[i], 2);
+    i += 2;
+    if (!tpm2_util_is_big_endian()) {
+        digest->size = tpm2_util_endian_swap_16(digest->size);
+    }
+
+    if (digest->size + i > quoted->size) {
+        LOG_ERR("Malformed TPM2B_DIGEST value");
+        return false;
+    }
+    memcpy(&digest->buffer, &quoted->attestationData[i], digest->size);
+
+    return true;
+}
+
 // verify that the quote digest equals the digest we calculated
 bool tpm2_util_verify_digests(TPM2B_DIGEST *quoteDigest,
         TPM2B_DIGEST *pcr_digest) {

--- a/man/common/tss2-options.md
+++ b/man/common/tss2-options.md
@@ -1,0 +1,17 @@
+# COMMON OPTIONS
+
+This collection of options are common to all tss2 programs and provide
+information that many users may expect.
+
+  * **-h**, **\--help [man|no-man]**:
+    Display the tools manpage. By default, it attempts to invoke the manpager for the tool,
+    however, on failure will output a short tool summary. This is the same behavior if the
+    "man" option argument is specified, however if explicit "man" is requested, the tool will
+    provide errors from man on stderr. If the "no-man" option if specified, or the manpager fails,
+    the short options will be output to stdout.
+
+    To successfully use the manpages feature requires the manpages to be installed or on
+    _MANPATH_, See **man**(1) for more details.
+
+  * **-v**, **\--version**:
+    Display version information for this tool, supported tctis and exit.

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -77,14 +77,17 @@ the various known TCTI modules.
 
 # EXAMPLES
 
+Create a primary key and certify it with a signing key.
+
 ```bash
-tpm2_certify -H 0x81010002 -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> \
--s <fileName>
+tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
-tpm2_certify -C obj.context -c key.context -P 0x0011 -p 0x00FF -g 0x00B \
--a <fileName> -s <fileName>
+tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv -C primary.ctx
 
-tpm2_certify -H 0x81010002 -P 0011 -p 00FF  -g 0x00B -a <fileName> -s <fileName>
+tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name \
+-c certify.ctx
+
+tpm2_certify -Q -c primary.ctx -C certify.ctx -g sha256 -o attest.out -s sig.out
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -24,16 +24,20 @@ if at least one of the policy events are true.
 
     File to save the compounded policy digest.
 
-  * **-l**, **\--policy-list**=_POLICY\_FILE_\_LIST:
-
-    The list of files for the policy digests that has to be compounded resulting
-    in individual policies being added to final policy digest that can
-    authenticate the object. The list begins with the policy digest hash alg.
-
   * **-S**, **\--session**=_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
+
+  * **ARGUMENT** the command line argument specifies the list of files for the
+    policy digests that has to be compounded resulting in individual policies
+    being added to final policy digest that can authenticate the object. The
+    list begins with the policy digest hash alg. Example sha256:policy1,policy2
+
+  * **-l**, **\--policy-list**=_POLICY\_FILE_\_LIST:
+
+    This option is retained for backwards compatibility. Use the argument method
+    instead.
 
 ## References
 
@@ -90,7 +94,7 @@ rm session.ctx
 tpm2_startauthsession -S session.ctx
 
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 tpm2_flushcontext session.ctx
 
@@ -114,7 +118,7 @@ tpm2_startauthsession -S session.ctx --policy-session
 tpm2_policypcr -S session.ctx -l sha1:23
 
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
 
@@ -140,7 +144,7 @@ tpm2_policypcr -S session.ctx -l sha1:23
 ### This should fail
 ```bash
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 tpm2_flushcontext session.ctx
 
@@ -159,7 +163,7 @@ tpm2_startauthsession -S session.ctx --policy-session
 tpm2_policypcr -S session.ctx -l sha1:23
 
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -13,7 +13,7 @@
 **tpm2_policyor**(1) - Generates a policy_or event with the TPM. It expects a
 session to be already established via **tpm2_startauthsession**(1). If
 the input session is a trial session this tool generates a policy digest that
-compounds two or more input  policy digests such that the resulting policy digest
+compounds two or more input policy digests such that the resulting policy digest
 requires at least one of the policy events being true. If the input session is
 real policy session **tpm2_policyor**(1) authenticates the object successfully
 if at least one of the policy events are true.
@@ -49,129 +49,54 @@ the various known TCTI modules.
 
 # EXAMPLES
 
-Creates two sets of PCR data files, one of them being the existing PCR values
-and other being a set of PCR values that would result if the PCR were extended
-with a known value. Now create two separate policy digests, each with one set
-of the PCR values using **tpm2_policypcr**(1) tool in *trial* sessions. Now
-build a policy_or with the two PCR policy digests as inputs. Create a sealing
-object with an authentication policy compounding the 2 policies with
-**tpm2_policyor** and seal a secret. Unsealing with either of the PCR sets
-should be successful.
+Create an authorization policy for a sealing object that compounds a pcr policy
+and a policypassword in an OR fashion and show satisfying either policies could
+unseal the secret.
 
-## Create two unique pcr policies with corresponding unique sets of pcrs.
-
-### Start with pcr value 0
-```bash
-tpm2_pcrreset 23
-```
-
-### PCR1 policy
+## Create policypcr as first truth value for compounding the policies
 ```bash
 tpm2_startauthsession -S session.ctx
-
-tpm2_policypcr -S session.ctx -l sha1:23 -L set1.pcr0.policy
-
+tpm2_policypcr -S session.ctx -L policy.pcr -l sha256:0,1,2,3
 tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
-### PCR2 policy
-```bash
-tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
-
-tpm2_startauthsession -S session.ctx
-
-tpm2_policypcr -S session.ctx -l sha1:23 -L set2.pcr0.policy
-
-tpm2_flushcontext session.ctx
-
-rm session.ctx
-```
-
-## Create a policyOR resulting from compounding the two unique pcr policies in an OR fashion
+## Create policypassword as second truth value for compounding the policies
 ```bash
 tpm2_startauthsession -S session.ctx
-
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
+tpm2_policypassword -S session.ctx -L policy.pass
 tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
-## Create a sealing object with auth policyOR created above.
+## Compound the two policies in an OR fashion with tpm2_policyor command
 ```bash
-tpm2_createprimary -C o -c prim.ctx
-
-tpm2_create -g sha256 -u sealkey.pub -r sealkey.priv -L policyOR -C prim.ctx \
--i- <<< "secretpass"
-
-tpm2_load -C prim.ctx -c sealkey.ctx -u sealkey.pub -r sealkey.priv
+tpm2_startauthsession -S session.ctx
+tpm2_policyor -S session.ctx -L policy.or sha256:policy.pass,policy.pcr
+tpm2_flushcontext session.ctx
 ```
 
-## Attempt unsealing by satisfying the policyOR by satisfying SECOND of the two policies.
+## Create a sealing object and attach the auth policy from tpm2_policyor command
+```bash
+tpm2_createprimary -c prim.ctx -Q
+echo "secret" | tpm2_create -C prim.ctx -c key.ctx -u key.pub -r key.priv \
+-L policy.or -i-
+```
+
+## Satisfy auth policy using password and unseal the secret
 ```bash
 tpm2_startauthsession -S session.ctx --policy-session
-
-tpm2_policypcr -S session.ctx -l sha1:23
-
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
-unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
-
-echo $unsealed
-
+tpm2_policypassword -S session.ctx
+tpm2_policyor -S session.ctx sha256:policy.pass,policy.pcr
+tpm2_unseal -c key.ctx -p session:session.ctx
 tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
-## Extend the pcr to emulate tampering of the system software and hence the pcr value.
-```bash
-tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
-```
-
-## Attempt unsealing by trying to satisy the policOR by attempting to satisy one of the two policies.
+## Satisfy auth policy using pcr and unseal the secret
 ```bash
 tpm2_startauthsession -S session.ctx --policy-session
-
-tpm2_policypcr -S session.ctx -l sha1:23
-```
-
-### This should fail
-```bash
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
+tpm2_policypcr -S session.ctx -l sha256:0,1,2,3
+tpm2_policyor -S session.ctx sha256:policy.pass,policy.pcr
+tpm2_unseal -c key.ctx -p session:session.ctx
 tpm2_flushcontext session.ctx
-
-rm session.ctx
-```
-
-## Reset pcr to get back to the first set of pcr value
-```bash
-tpm2_pcrreset 23
-```
-
-## Attempt unsealing by satisfying the policyOR by satisfying FIRST of the two policies.
-```bash
-tpm2_startauthsession -S session.ctx --policy-session
-
-tpm2_policypcr -S session.ctx -l sha1:23
-
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
-unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
-
-echo $unsealed
-
-tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
 [returns](common/returns.md)

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -1,0 +1,40 @@
+% tss2_authorizepolicy(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_authorizepolicy**(1) -
+
+# SYNOPSIS
+
+**tss2_authorizepolicy** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_authorizepolicy**(1) - This command signs a given policy with a given key such that the policy can be referenced from other policies that contain a corresponding PolicyAuthorize elements.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-P**, **\--policyPath**:
+    Path of the new policy. MUST NOT be NULL.
+
+  * **-p**, **\--keyPath**:
+    Path of the signing key. MUST NOT be NULL.
+
+  * **-r**, **\--policyRef**:
+    A byte buffer to be included in the signature. MAY be NULL if policyRefSize is 0.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_authorizepolicy --keyPath HS/SRK/myPolicySignKey --policyPath policy/pcr-policy --policyRef policyRef.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-p**, **\--policyPath**:
+  * **-P**, **\--policyPath**:
     Path of the new policy. MUST NOT be NULL.
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
     Path of the signing key. MUST NOT be NULL.
 
-  * **-r**, **\--policyRef**=:
+  * **-r**, **\--policyRef**:
     A byte buffer to be included in the signature. MAY be NULL if policyRefSize is 0.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -1,0 +1,40 @@
+% tss2_authorizepolicy(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_authorizepolicy**(1) -
+
+# SYNOPSIS
+
+**tss2_authorizepolicy** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_authorizepolicy**(1) - This command signs a given policy with a given key such that the policy can be referenced from other policies that contain a corresponding PolicyAuthorize elements.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--policyPath**:
+    Path of the new policy. MUST NOT be NULL.
+
+  * **-k**, **\--keyPath**=:
+    Path of the signing key. MUST NOT be NULL.
+
+  * **-r**, **\--policyRef**=:
+    A byte buffer to be included in the signature. MAY be NULL if policyRefSize is 0.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_authorizepolicy --keyPath HS/SRK/myPolicySignKey --policyPath policy/pcr-policy --policyRef policyRef.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -24,7 +24,7 @@ These are the available options:
 
     The new 0-terminated password. MAY be NULL. If NULL then the password is set to the empty string.
 
-  * **-e**, **\--entityPath**=:
+  * **-p**, **\--entityPath**:
 
     The path identifying the entity to modify. MUST NOT be NULL.
 
@@ -34,7 +34,7 @@ These are the available options:
 
 ## Change a password for an entity HS/SRK/myRSACryptKey to M1
 ```
-tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue=M1
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue M1
 ```
 
 ## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password with disabled ecoh.

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -1,0 +1,49 @@
+% tss2_changeauth(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_changeauth**(1) - This command changes the authorization data of an entity referred to by the path.
+
+The authValue is a UTF-8 password. If the length of the password is larger than the digest size of the entity's nameAlg (which is stored internally as part of its meta data) then the FAPI should hash the password, in accordance with the TPM specification, part 1 rev 138, section 19.6.4.3 "Authorization Size Convention."
+
+# SYNOPSIS
+
+**tss2_changeauth** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_changeauth**(1) -
+
+# OPTIONS
+
+These are the available options:
+
+  * **-a**, **\--authValue**:
+
+    The new 0-terminated password. MAY be NULL. If NULL then the password is set to the empty string.
+
+  * **-e**, **\--entityPath**=:
+
+    The path identifying the entity to modify. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLES
+
+## Change a password for an entity HS/SRK/myRSACryptKey to M1
+```
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue=M1
+```
+
+## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password with disabled ecoh.
+```
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -1,0 +1,49 @@
+% tss2_changeauth(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_changeauth**(1) - This command changes the authorization data of an entity referred to by the path.
+
+The authValue is a UTF-8 password. If the length of the password is larger than the digest size of the entity's nameAlg (which is stored internally as part of its meta data) then the FAPI should hash the password, in accordance with the TPM specification, part 1 rev 138, section 19.6.4.3 "Authorization Size Convention."
+
+# SYNOPSIS
+
+**tss2_changeauth** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_changeauth**(1) -
+
+# OPTIONS
+
+These are the available options:
+
+  * **-a**, **\--authValue**:
+
+    The new 0-terminated password. MAY be NULL. If NULL then the password is set to the empty string.
+
+  * **-p**, **\--entityPath**:
+
+    The path identifying the entity to modify. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLES
+
+## Change a password for an entity HS/SRK/myRSACryptKey to M1
+```
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue M1
+```
+
+## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password with disabled ecoh.
+```
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -1,0 +1,60 @@
+% tss2_createkey(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_createkey**(1) -
+
+# SYNOPSIS
+
+**tss2_createkey** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_createkey**(1) - This commands creates a key inside the TPM and stores it in the FAPI metadata store and if requested persistently inside the TPM.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    The path to the new key. MUST NOT be NULL.
+
+  * **-t**, **\--type**:
+
+    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+
+  * **-P**, **\--policyPath**:
+
+    The policy to be associated with the new key. policyPath MAY be NULL. If NULL then no policy will be associated with the key.
+
+  * **-a**, **\--authValue**:
+
+    The new authorization value for the key. authValue MAY be NULL. If NULL then the authorization value will be the empty string.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+## Create a key without password
+```
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt"
+```
+
+## Create a key, ask for password on the command line
+```
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue
+```
+
+## Create a key with password “abc”.
+```
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue abc
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path to the new key. MUST NOT be NULL.
 
@@ -26,7 +26,7 @@ These are the available options:
 
     Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
 
-  * **-l**, **\--policyPath**:
+  * **-P**, **\--policyPath**:
 
     The policy to be associated with the new key. policyPath MAY be NULL. If NULL then no policy will be associated with the key.
 
@@ -50,7 +50,7 @@ tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue
 
 ## Create a key with password “abc”.
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue=abc
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue abc
 ```
 
 # RETURNS

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -1,0 +1,60 @@
+% tss2_createkey(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_createkey**(1) -
+
+# SYNOPSIS
+
+**tss2_createkey** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_createkey**(1) - This commands creates a key inside the TPM and stores it in the FAPI metadata store and if requested persistently inside the TPM.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    The path to the new key. MUST NOT be NULL.
+
+  * **-t**, **\--type**:
+
+    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+
+  * **-l**, **\--policyPath**:
+
+    The policy to be associated with the new key. policyPath MAY be NULL. If NULL then no policy will be associated with the key.
+
+  * **-a**, **\--authValue**:
+
+    The new authorization value for the key. authValue MAY be NULL. If NULL then the authorization value will be the empty string.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+## Create a key without password
+```
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt"
+```
+
+## Create a key, ask for password on the command line
+```
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue
+```
+
+## Create a key with password “abc”.
+```
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue=abc
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     Path of the new NV space. MUST NOT be NULL.
 
@@ -30,13 +30,13 @@ These are the available options:
 
     The size in bytes of the NV index to be created. MAY be zero if the size is inferred from the type; e.g. an NV index of type counter has a size of 8 bytes.
 
-  * **-P**, **\--policy-path**:
+  * **-P**, **\--policyPath**:
 
     Identifies the policy to be associated with the new NV space. MAY be NULL. If NULL then no policy will be associated with the NV space.
 
   * **-a**, **\--authValue**:
 
-    The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string
+    The new authorization value for the nv index. MAY be NULL. If NULL then the authorization value will be the empty string
 
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -1,0 +1,52 @@
+% tss2_createnv(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_createnv**(1) -
+
+# SYNOPSIS
+
+**tss2_createnv** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_createnv**(1) - This command creates an NV index in the TPM. The path is constructed as described in section 1.7.2. The type field is described in section 1.8.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    Path of the new NV space. MUST NOT be NULL.
+
+  * **-t**, **\--type**:
+
+    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+
+  * **-s**, **\--size**:
+
+    The size in bytes of the NV index to be created. MAY be zero if the size is inferred from the type; e.g. an NV index of type counter has a size of 8 bytes.
+
+  * **-P**, **\--policy-path**:
+
+    Identifies the policy to be associated with the new NV space. MAY be NULL. If NULL then no policy will be associated with the NV space.
+
+  * **-a**, **\--authValue**:
+
+    The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_createnv --authValue abc --path /nv/Owner/myNV --size 20 --type "noDa"
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -1,0 +1,52 @@
+% tss2_createnv(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_createnv**(1) -
+
+# SYNOPSIS
+
+**tss2_createnv** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_createnv**(1) - This command creates an NV index in the TPM. The path is constructed as described in section 1.7.2. The type field is described in section 1.8.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    Path of the new NV space. MUST NOT be NULL.
+
+  * **-t**, **\--type**:
+
+    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+
+  * **-s**, **\--size**:
+
+    The size in bytes of the NV index to be created. MAY be zero if the size is inferred from the type; e.g. an NV index of type counter has a size of 8 bytes.
+
+  * **-P**, **\--policyPath**:
+
+    Identifies the policy to be associated with the new NV space. MAY be NULL. If NULL then no policy will be associated with the NV space.
+
+  * **-a**, **\--authValue**:
+
+    The new authorization value for the nv index. MAY be NULL. If NULL then the authorization value will be the empty string
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_createnv --authValue abc --path /nv/Owner/myNV --size 20 --type "noDa"
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -1,0 +1,54 @@
+% tss2_createseal(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_createseal**(1) -
+
+# SYNOPSIS
+
+**tss2_createseal** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_createseal**(1) - This command creates a sealed object and stores it in the FAPI metadata store. If no data is provided (i.e. a NULL-pointer) then the TPM generates random data and fills the sealed object.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    The path to the new key. MUST NOT be NULL.
+
+  * **-t**, **\--type**:
+
+    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+
+  * **-P**, **\--policyPath**:
+
+    Identifies the policy to be associated with the new key. MAY be NULL. If NULL then no policy will be associated with the key.
+
+  * **-a**, **\--authValue**:
+
+    The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string.
+
+  * **-i**, **\--data**:
+
+    the data to be sealed by the TPM. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+## Create a key without password and read data to be sealed from file.
+```
+tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data abc
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path to the new key. MUST NOT be NULL.
 
@@ -34,7 +34,7 @@ These are the available options:
 
     The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string.
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     the data to be sealed by the TPM. MAY be NULL.
 
@@ -44,7 +44,7 @@ These are the available options:
 
 ## Create a key without password and read data to be sealed from file.
 ```
-tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue=abc --data abc
+tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data abc
 ```
 
 # RETURNS

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -1,0 +1,54 @@
+% tss2_createseal(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_createseal**(1) -
+
+# SYNOPSIS
+
+**tss2_createseal** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_createseal**(1) - This command creates a sealed object and stores it in the FAPI metadata store. If no data is provided (i.e. a NULL-pointer) then the TPM generates random data and fills the sealed object.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    The path to the new key. MUST NOT be NULL.
+
+  * **-t**, **\--type**:
+
+    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+
+  * **-P**, **\--policyPath**:
+
+    Identifies the policy to be associated with the new key. MAY be NULL. If NULL then no policy will be associated with the key.
+
+  * **-a**, **\--authValue**:
+
+    The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string.
+
+  * **-d**, **\--data**:
+
+    the data to be sealed by the TPM. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+## Create a key without password and read data to be sealed from file.
+```
+tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue=abc --data abc
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -1,0 +1,47 @@
+% tss2_decrypt(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_decrypt**(1) - decrypts data
+
+# SYNOPSIS
+
+**tss2_decrypt** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_decrypt**(1) - Input pointer to data to be decrypted, and a place to put the decrypted data.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-k**, **\--keyPath**=:
+
+    Identifies the decryption key. MUST NOT be NULL.
+
+  * **-c**, **\--cipherText**: \<filename\>
+
+    The JSON-encoded cipherText. MUST NOT be NULL.
+
+  * **-f**, **\--force**:
+
+    Force Overwriting the output file.
+
+  * **-p**, **\--plainText**: \<filename\>
+
+    Returns the decrypted data. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText=encrypted.file --plainText=-
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -1,0 +1,47 @@
+% tss2_decrypt(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_decrypt**(1) - decrypts data
+
+# SYNOPSIS
+
+**tss2_decrypt** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_decrypt**(1) - Input pointer to data to be decrypted, and a place to put the decrypted data.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--keyPath**:
+
+    Identifies the decryption key. MUST NOT be NULL.
+
+  * **-i**, **\--cipherText**: \<filename\>
+
+    The JSON-encoded cipherText. MUST NOT be NULL.
+
+  * **-f**, **\--force**:
+
+    Force Overwriting the output file.
+
+  * **-o**, **\--plainText**: \<filename\>
+
+    Returns the decrypted data. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText encrypted.file --plainText abc
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     Identifies the decryption key. MUST NOT be NULL.
 
-  * **-c**, **\--cipherText**: \<filename\>
+  * **-i**, **\--cipherText**: \<filename\>
 
     The JSON-encoded cipherText. MUST NOT be NULL.
 
@@ -30,7 +30,7 @@ These are the available options:
 
     Force Overwriting the output file.
 
-  * **-p**, **\--plainText**: \<filename\>
+  * **-o**, **\--plainText**: \<filename\>
 
     Returns the decrypted data. MAY be NULL.
 
@@ -38,7 +38,7 @@ These are the available options:
 
 # EXAMPLE
 
-    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText=encrypted.file --plainText=-
+    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText encrypted.file --plainText abc
 
 # RETURNS
 

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -27,7 +27,7 @@ actions SHALL be taken:
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path to the entity to delete. MUST NOT be NULL.
 
@@ -37,7 +37,7 @@ These are the available options:
 
 # Deletes storage hierarchy (HS) and everything below it:
 ```
-tss2_delete --path=HS
+tss2_delete --path /HS
 ```
 
 # RETURNS

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -1,0 +1,47 @@
+% tss2_delete(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_delete**(1) - This command deletes the given key, policy or NV from the system. Depending on the entity type, one of the following
+actions SHALL be taken:
+
+    * Non-persistent key: Flush from TPM (if loaded) and delete blobs public and private blobs from keystore.
+    * Persistent keys: Evict from TPM and delete public and private blobs from keystore
+    * Primary keys: Flush from TPM and delete public blobs from keystore
+    * NV index: Undefine NV index from TPM and delete public blob from metadata store
+    * Policies: Delete entry from policy store
+    * Hierarchy, PCR: Return TSS2_FAPI_RC_NOT_DELETABLE
+    * Special keys EK, SRK: Return TSS2_FAPI_RC_NOT_DELETABLE
+
+# SYNOPSIS
+
+**tss2_delete** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_delete**(1) -
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    The path to the entity to delete. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+# Deletes storage hierarchy (HS) and everything below it:
+```
+tss2_delete --path=HS
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -1,0 +1,47 @@
+% tss2_delete(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_delete**(1) - This command deletes the given key, policy or NV from the system. Depending on the entity type, one of the following
+actions SHALL be taken:
+
+    * Non-persistent key: Flush from TPM (if loaded) and delete blobs public and private blobs from keystore.
+    * Persistent keys: Evict from TPM and delete public and private blobs from keystore
+    * Primary keys: Flush from TPM and delete public blobs from keystore
+    * NV index: Undefine NV index from TPM and delete public blob from metadata store
+    * Policies: Delete entry from policy store
+    * Hierarchy, PCR: Return TSS2_FAPI_RC_NOT_DELETABLE
+    * Special keys EK, SRK: Return TSS2_FAPI_RC_NOT_DELETABLE
+
+# SYNOPSIS
+
+**tss2_delete** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_delete**(1) -
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    The path to the entity to delete. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+# Deletes storage hierarchy (HS) and everything below it:
+```
+tss2_delete --path /HS
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -1,0 +1,60 @@
+% tss2_encrypt(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_encrypt**(1) - encrypts data
+
+# SYNOPSIS
+
+**tss2_encrypt** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_encrypt**(1) - This command encrypts the provided data for a target key.
+
+If keypath is an asymmetric key and a plaintext with size >= TPM2_MAX_SYM_SIZE is provided, Fapi_Encrypt() will bulk-encrypt the plaintext with an intermediate symmetric key and then “seal” this intermediate symmetric key with keyPath as a KEYEDHASH TPM object. This keyPath may refer to the local TPM or to a public key of a remote TPM where the KEYEDHASH can be imported. The decrypt operation performs a TPM2_Unseal. ciphertext output contains a reference to the decryption key, the sealed symmetric key (if any), the policy instance, and the encrypted plaintext.
+
+If plaintext has a size <= TPM2_MAX_SYM_SIZE the plaintext is sealed directly for keyPath.
+
+If encrypting for the local TPM (if keyPath is not from the external hierarchy), a storage key (symmetric or asymmetric) is required as keyPath (aka parent key) and the data intermediate symmetric key is created using TPM2_Create() as a KEYEDHASH object.
+
+If encrypting for a remote TPM, an asymmetric storage key is required as keyPath (aka parent key), and the data/intermediate symmetric key is encrypted such that it can be used in a TPM2_Import operation. The format of the cipherText is described in the FAPI specification.
+
+
+# OPTIONS
+
+These are the available options:
+
+  * **-k**, **\--keyPath**=:
+
+    Identifies the encryption key. MUST NOT be NULL.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--policyPath**:
+
+    Identifies the policy to be associated with the sealed data. MAY be NULL. If NULL then the sealed data will have no policy.
+
+  * **-P**, **\--plainText**:
+
+    The data to be encrypted. MUST NOT be NULL.
+
+  * **-c**, **\--cipherText**:
+
+    Returns the JSON-encoded ciphertext. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+  tss2_encrypt --keyPath HS/SRK/myRSACrypt --plainText plaintext.file --cipherText encrypted.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -1,0 +1,60 @@
+% tss2_encrypt(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_encrypt**(1) - encrypts data
+
+# SYNOPSIS
+
+**tss2_encrypt** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_encrypt**(1) - This command encrypts the provided data for a target key.
+
+If keypath is an asymmetric key and a plaintext with size >= TPM2_MAX_SYM_SIZE is provided, Fapi_Encrypt() will bulk-encrypt the plaintext with an intermediate symmetric key and then “seal” this intermediate symmetric key with keyPath as a KEYEDHASH TPM object. This keyPath may refer to the local TPM or to a public key of a remote TPM where the KEYEDHASH can be imported. The decrypt operation performs a TPM2_Unseal. ciphertext output contains a reference to the decryption key, the sealed symmetric key (if any), the policy instance, and the encrypted plaintext.
+
+If plaintext has a size <= TPM2_MAX_SYM_SIZE the plaintext is sealed directly for keyPath.
+
+If encrypting for the local TPM (if keyPath is not from the external hierarchy), a storage key (symmetric or asymmetric) is required as keyPath (aka parent key) and the data intermediate symmetric key is created using TPM2_Create() as a KEYEDHASH object.
+
+If encrypting for a remote TPM, an asymmetric storage key is required as keyPath (aka parent key), and the data/intermediate symmetric key is encrypted such that it can be used in a TPM2_Import operation. The format of the cipherText is described in the FAPI specification.
+
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--keyPath**:
+
+    Identifies the encryption key. MUST NOT be NULL.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-P**, **\--policyPath**:
+
+    Identifies the policy to be associated with the sealed data. MAY be NULL. If NULL then the sealed data will have no policy.
+
+  * **-i**, **\--plainText**:
+
+    The data to be encrypted. MUST NOT be NULL.
+
+  * **-o**, **\--cipherText**:
+
+    Returns the JSON-encoded ciphertext. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+  tss2_encrypt --keyPath HS/SRK/myRSACrypt --plainText plaintext.file --cipherText encrypted.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -27,7 +27,7 @@ If encrypting for a remote TPM, an asymmetric storage key is required as keyPath
 
 These are the available options:
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     Identifies the encryption key. MUST NOT be NULL.
 
@@ -35,15 +35,15 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--policyPath**:
+  * **-P**, **\--policyPath**:
 
     Identifies the policy to be associated with the sealed data. MAY be NULL. If NULL then the sealed data will have no policy.
 
-  * **-P**, **\--plainText**:
+  * **-i**, **\--plainText**:
 
     The data to be encrypted. MUST NOT be NULL.
 
-  * **-c**, **\--cipherText**:
+  * **-o**, **\--cipherText**:
 
     Returns the JSON-encoded ciphertext. MUST NOT be NULL.
 

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -1,0 +1,47 @@
+% tss2_exportkey(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_exportkey**(1) -
+
+# SYNOPSIS
+
+**tss2_exportkey** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_exportkey**(1) - This command will duplicate a key and encrypt it using the public key of a new parent. The exported data will contain the re-wrapped key pointed to by the pathOfKeyToDuplicate and then the JSON encoded policy. The exported data SHALL be encoded as described in the FAPI specification.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-e** **\--pathToPublicKeyOfNewParent**:
+
+    The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext. If NULL only the public key will exported.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-o**, **\--exportedData**:
+
+    Returns the exported subtree. MUST NOT be NULL.
+
+  * **-p**, **\--pathOfKeyToDuplicate**:
+
+    The path to the root of the subtree to export. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_exportkey --pathOfKeyToDuplicate HS/SRK/myRSADecrypt --exportedData exportedPublicKey
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-P** **\--pathToPublicKeyOfNewParent**:
+  * **-e** **\--pathToPublicKeyOfNewParent**:
 
     The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext. If NULL only the public key will exported.
 
@@ -26,7 +26,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-e**, **\--exportedData**:
+  * **-o**, **\--exportedData**:
 
     Returns the exported subtree. MUST NOT be NULL.
 

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -1,0 +1,47 @@
+% tss2_exportkey(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_exportkey**(1) -
+
+# SYNOPSIS
+
+**tss2_exportkey** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_exportkey**(1) - This command will duplicate a key and encrypt it using the public key of a new parent. The exported data will contain the re-wrapped key pointed to by the pathOfKeyToDuplicate and then the JSON encoded policy. The exported data SHALL be encoded as described in the FAPI specification.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-P** **\--pathToPublicKeyOfNewParent**:
+
+    The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext. If NULL only the public key will exported.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-e**, **\--exportedData**:
+
+    Returns the exported subtree. MUST NOT be NULL.
+
+  * **-p**, **\--pathOfKeyToDuplicate**:
+
+    The path to the root of the subtree to export. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_exportkey --pathOfKeyToDuplicate HS/SRK/myRSADecrypt --exportedData exportedPublicKey
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -1,0 +1,44 @@
+% tss2_policyexport(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_policyexport**(1) -
+
+# SYNOPSIS
+
+**tss2_policyexport** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_policyexport**(1) - This commands exports a policy associated with a key
+in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-o**, **\--jsonPolicy**:
+
+    Returns the JSON-encoded policy. MUST NOT be NULL.
+
+  * **-p**, **\--path**:
+
+    The path of the key. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_exportpolicy --path HS/SRK/myRSASign --jsonPolicy pcr-policy.json
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -12,7 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_policyexport**(1) - This commands exports a policy referred to by a path in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
+**tss2_policyexport**(1) - This commands exports a policy associated with a key
+in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
 
 # OPTIONS
 
@@ -22,13 +23,13 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-j**, **\--jsonPolicy**:
+  * **-o**, **\--jsonPolicy**:
 
     Returns the JSON-encoded policy. MUST NOT be NULL.
 
   * **-p**, **\--path**:
 
-    The path of the new policy. MUST NOT be NULL.
+    The path of the key. MUST NOT be NULL.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -1,0 +1,43 @@
+% tss2_policyexport(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_policyexport**(1) -
+
+# SYNOPSIS
+
+**tss2_policyexport** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_policyexport**(1) - This commands exports a policy referred to by a path in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-j**, **\--jsonPolicy**:
+
+    Returns the JSON-encoded policy. MUST NOT be NULL.
+
+  * **-p**, **\--path**:
+
+    The path of the new policy. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_exportpolicy --path HS/SRK/myRSASign --jsonPolicy pcr-policy.json
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -1,0 +1,41 @@
+% tss2_getappdata(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getappdata**(1)
+
+# SYNOPSIS
+
+**tss2_getappdata** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getappdata**(1) - This command returns the previously stored application data for an object. If no application data is present, then appDataSize SHALL be 0.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    Path of the object for which the appData will be loaded. MUST NOT be NULL.
+
+  * **-a**, **\--appData**:
+
+    Returns a copy of the stored data. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_getappdata --path HS/SRK/myRSACrypt --appData appData
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -1,0 +1,41 @@
+% tss2_getappdata(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getappdata**(1)
+
+# SYNOPSIS
+
+**tss2_getappdata** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getappdata**(1) - This command returns the previously stored application data for an object. If no application data is present, then appDataSize SHALL be 0.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    Path of the object for which the appData will be loaded. MUST NOT be NULL.
+
+  * **-o**, **\--appData**:
+
+    Returns a copy of the stored data. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_getappdata --path HS/SRK/myRSACrypt --appData appData
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Path of the object for which the appData will be loaded. MUST NOT be NULL.
 
-  * **-a**, **\--appData**:
+  * **-o**, **\--appData**:
 
     Returns a copy of the stored data. MAY be NULL.
 

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -1,0 +1,43 @@
+% tss2_getcertificate(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getcertificate**(1) -
+
+# SYNOPSIS
+
+**tss2_getcertificate** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getcertificate**(1) - This command returns the PEM encoded X.509 certificate associated with the key at path.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**=:
+
+    The entity whose certificate is requested. MUST NOT be NULL.
+
+  * **-x**, **\--x509certData**:
+
+    Returns the PEM encoded certificate. MUST NOT be NULL. If no certificate is stored, then an empty string is returned.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_getcertificate --path HS/SRK/myRSACrypt --x509certData myRSACrypt.cert
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The entity whose certificate is requested. MUST NOT be NULL.
 
-  * **-x**, **\--x509certData**:
+  * **-o**, **\--x509certData**:
 
     Returns the PEM encoded certificate. MUST NOT be NULL. If no certificate is stored, then an empty string is returned.
 

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -1,0 +1,43 @@
+% tss2_getcertificate(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getcertificate**(1) -
+
+# SYNOPSIS
+
+**tss2_getcertificate** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getcertificate**(1) - This command returns the PEM encoded X.509 certificate associated with the key at path.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
+
+    The entity whose certificate is requested. MUST NOT be NULL.
+
+  * **-o**, **\--x509certData**:
+
+    Returns the PEM encoded certificate. MUST NOT be NULL. If no certificate is stored, then an empty string is returned.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_getcertificate --path HS/SRK/myRSACrypt --x509certData myRSACrypt.cert
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -18,11 +18,15 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
 
     The path of the object for which the appData will be loaded. MUST NOT be NULL.
 
-  * **-d**, **\--description**=:
+  * **-o**, **\--description**:
 
     Returns the stored description. MUST NOT be NULL.
 

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -1,0 +1,41 @@
+% tss2_getdescription(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getdescription**(1)
+
+# SYNOPSIS
+
+**tss2_getdescription** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getdescription**(1) - This command returns the previously stored application data for an object. If no description is present, description SHALL be set to an empty string.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    The path of the object for which the appData will be loaded. MUST NOT be NULL.
+
+  * **-d**, **\--description**=:
+
+    Returns the stored description. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_getdescription --path HS/SRK --description description.file
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -1,0 +1,45 @@
+% tss2_getdescription(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getdescription**(1)
+
+# SYNOPSIS
+
+**tss2_getdescription** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getdescription**(1) - This command returns the previously stored application data for an object. If no description is present, description SHALL be set to an empty string.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
+
+    The path of the object for which the appData will be loaded. MUST NOT be NULL.
+
+  * **-o**, **\--description**:
+
+    Returns the stored description. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_getdescription --path HS/SRK --description description.file
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -1,0 +1,40 @@
+% tss2_getinfo(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getinfo**(1) -
+
+# SYNOPSIS
+
+**tss2_getinfo** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getinfo**(1) - This command returns a UTF-8 string identifying the version of the FAPI, the TPM, configurations and other relevant information in a human readable format. The concrete content of this string is implementation specific.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-o**, **\--info**:
+
+    Returns the FAPI and TPM information. MUST NOT be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_getinfo --info data.info
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -1,0 +1,40 @@
+% tss2_getinfo(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getinfo**(1) -
+
+# SYNOPSIS
+
+**tss2_getinfo** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getinfo**(1) - This command returns a UTF-8 string identifying the version of the FAPI, the TPM, configurations and other relevant information in a human readable format. The concrete content of this string is implementation specific.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-i**, **\--info**:
+
+    Returns the FAPI and TPM information. MUST NOT be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_getinfo --info data.info
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-i**, **\--info**:
+  * **-o**, **\--info**:
 
     Returns the FAPI and TPM information. MUST NOT be NULL.
 

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_getplatformcertificates**(1) - This command returns the set of Platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.
+**tss2_getplatformcertificates**(1) - This command returns the set of platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.
 
 # OPTIONS
 
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-c**, **\--certificates**:
+  * **-o**, **\--certificates**:
 
     Returns a continuous buffer containing the concatenated platform certificates. MUST NOT be NULL.
 

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -1,0 +1,39 @@
+% tss2_getplatformcertificates(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getplatformcertificates**(1) -
+
+# SYNOPSIS
+
+**tss2_getplatformcertificates** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getplatformcertificates**(1) - This command returns the set of platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-o**, **\--certificates**:
+
+    Returns a continuous buffer containing the concatenated platform certificates. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_getplatformcertificates --certificates platform.certs
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -1,0 +1,39 @@
+% tss2_getplatformcertificates(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getplatformcertificates**(1) -
+
+# SYNOPSIS
+
+**tss2_getplatformcertificates** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getplatformcertificates**(1) - This command returns the set of Platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-c**, **\--certificates**:
+
+    Returns a continuous buffer containing the concatenated platform certificates. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_getplatformcertificates --certificates platform.certs
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -26,7 +26,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-d**, **\--data**: \<filename\>
+  * **-o**, **\--data**: \<filename\>
 
     The returned random bytes. MUST NOT be NULL.
 

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -1,0 +1,43 @@
+% tss2_getrandom(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getrandom**(1) -
+# SYNOPSIS
+
+**tss2_getrandom** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getrandom**(1) - This command uses the TPM to create an array of random bytes. This function may perform multiple calls to the TPM if the number of bytes requested by the caller is larger than the maximum number of bytes that the TPM will return per call.
+
+
+# OPTIONS
+
+These are the available options:
+
+  * **-n**, **\--numBytes**: \<number\>
+
+    The number of bytes requested by the caller
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-d**, **\--data**: \<filename\>
+
+    The returned random bytes. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+    tss2_getrandom --numBytes 20 -data - | hexdump -C
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -1,0 +1,43 @@
+% tss2_getrandom(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_getrandom**(1) -
+# SYNOPSIS
+
+**tss2_getrandom** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_getrandom**(1) - This command uses the TPM to create an array of random bytes. This function may perform multiple calls to the TPM if the number of bytes requested by the caller is larger than the maximum number of bytes that the TPM will return per call.
+
+
+# OPTIONS
+
+These are the available options:
+
+  * **-n**, **\--numBytes**: \<number\>
+
+    The number of bytes requested by the caller
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-o**, **\--data**: \<filename\>
+
+    The returned random bytes. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+    tss2_getrandom --numBytes 20 -data - | hexdump -C
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -42,7 +42,7 @@ These are the available options:
 
 # EXAMPLE
 
-tss2_gettpmblobs --path=HS/SRK/myRSACrypt --tpm2bPublic=public.file --tpm2bPrivate=private.file --policy=policy.file
+tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic public.file --tpm2bPrivate private.file --policy policy.file
 
 # RETURNS
 

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -1,0 +1,51 @@
+% tss2_gettpmblobs(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_gettpmblobs**(1) -
+
+# SYNOPSIS
+
+**tss2_gettpmblobs** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_gettpmblobs**(1) - This command returns the public and private blobs of an object, such that they could be loaded by a low-level API (e.g. ESAPI). It also returns the policy associated with these blobs in JSON format.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
+
+    The path of the object for which the blobs will be returned. MUST NOT be NULL.
+
+  * **-u**, **\--tpm2bPublic**:
+
+    The returned public area of the object as a marshalled TPM2B_PUBLIC. MAY be NULL.
+
+  * **-r**, **\--tpm2bPrivate**:
+
+    The returned private area of the object as a marshalled TPM2B_PRIVATE. MAY be NULL.
+
+  * **-l**, **\--policy**:
+
+    The returned policy associated with the object, encoded in JSON. policy MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic public.file --tpm2bPrivate private.file --policy policy.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -1,0 +1,51 @@
+% tss2_gettpmblobs(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_gettpmblobs**(1) -
+
+# SYNOPSIS
+
+**tss2_gettpmblobs** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_gettpmblobs**(1) - This command returns the public and private blobs of an object, such that they could be loaded by a low-level API (e.g. ESAPI). It also returns the policy associated with these blobs in JSON format.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
+
+    The path of the object for which the blobs will be returned. MUST NOT be NULL.
+
+  * **-u**, **\--tpm2bPublic**:
+
+    The returned public area of the object as a marshalled TPM2B_PUBLIC. MAY be NULL.
+
+  * **-r**, **\--tpm2bPrivate**:
+
+    The returned private area of the object as a marshalled TPM2B_PRIVATE. MAY be NULL.
+
+  * **-l**, **\--policy**:
+
+    The returned policy associated with the object, encoded in JSON. policy MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_gettpmblobs --path=HS/SRK/myRSACrypt --tpm2bPublic=public.file --tpm2bPrivate=private.file --policy=policy.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -1,0 +1,42 @@
+% tss2_import(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_import**(1) -
+
+# SYNOPSIS
+
+**tss2_import** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_import**(1) - This command imports a JSON encoded policy or policy template encoded according to TCG TSS 2.0 JSON Policy Language Specification and stores it under the provided path or it imports a JSON encoded key under the provided path.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    The path of the new object. MUST NOT be NULL.
+
+  * **-d**, **\--importData=**:
+
+    The data to be imported. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_import --path duplicate_policy --importData pol_duplicate.json
+
+tss2_import --path importedPubKey --importData public_key.file
+
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path of the new object. MUST NOT be NULL.
 
-  * **-d**, **\--importData=**:
+  * **-i**, **\--importData**:
 
     The data to be imported. MUST NOT be NULL.
 

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -1,0 +1,42 @@
+% tss2_import(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_import**(1) -
+
+# SYNOPSIS
+
+**tss2_import** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_import**(1) - This command imports a JSON encoded policy or policy template encoded according to TCG TSS 2.0 JSON Policy Language Specification and stores it under the provided path or it imports a JSON encoded key under the provided path.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    The path of the new object. MUST NOT be NULL.
+
+  * **-i**, **\--importData**:
+
+    The data to be imported. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_import --path duplicate_policy --importData pol_duplicate.json
+
+tss2_import --path importedPubKey --importData public_key.file
+
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -1,0 +1,46 @@
+% tss2_list(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_list**(1) -
+
+# SYNOPSIS
+
+**tss2_list** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_list**(1) - This command enumerates all objects in the metadata store in a given a path. The returned list SHALL consist of complete paths from the root (not relative paths from the search path), such that they can be directly used in another query. The values in this list SHALL be colon-separated.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-s**, **\--searchPath**:
+
+    The path identifying the root of the search. MUST NOT be NULL.
+
+  * **-p**, **\--pathList**:
+
+    Returns the colon-separated list of paths. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLES
+
+## List all entities
+```
+tss2_list
+```
+## List all entities under the HS path
+```
+tss2_list --searchPath=HS --pathList output.file
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -1,0 +1,46 @@
+% tss2_list(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_list**(1) -
+
+# SYNOPSIS
+
+**tss2_list** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_list**(1) - This command enumerates all objects in the metadata store in a given a path. The returned list SHALL consist of complete paths from the root (not relative paths from the search path), such that they can be directly used in another query. The values in this list SHALL be colon-separated.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--searchPath**:
+
+    The path identifying the root of the search. MUST NOT be NULL.
+
+  * **-o**, **\--pathList**:
+
+    Returns the colon-separated list of paths. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLES
+
+## List all entities
+```
+tss2_list
+```
+## List all entities under the HS path
+```
+tss2_list --searchPath HS --pathList output.file
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-s**, **\--searchPath**:
+  * **-p**, **\--searchPath**:
 
     The path identifying the root of the search. MUST NOT be NULL.
 
-  * **-p**, **\--pathList**:
+  * **-o**, **\--pathList**:
 
     Returns the colon-separated list of paths. MUST NOT be NULL.
 
@@ -36,7 +36,7 @@ tss2_list
 ```
 ## List all entities under the HS path
 ```
-tss2_list --searchPath=HS --pathList output.file
+tss2_list --searchPath HS --pathList output.file
 ```
 
 # RETURNS

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -1,0 +1,43 @@
+% tss2_nvextend(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvextend**(1) -
+
+# SYNOPSIS
+
+**tss2_nvextend** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvextend**(1) - This command performs an extend options on an NV index of type extend (i.e. an NV index that behaves similar to a PCR).
+
+# OPTIONS
+
+These are the available options:
+
+  * **-d**, **\--data**:
+
+    The data to be extended into the NV space. MUST NOT be NULL.
+
+  * **-n**, **\--nvPath**:
+
+    Identifies the NV space to write. MUST NOT be NULL.
+
+  * **-l**, **\--logData**:
+
+    A JSON representation of data to be written to the PCR’s event log. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvextend --nvPath /nv/Owner/NvExtend --data nv_write_data.file --logData log.data
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -1,0 +1,43 @@
+% tss2_nvextend(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvextend**(1) -
+
+# SYNOPSIS
+
+**tss2_nvextend** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvextend**(1) - This command performs an extend options on an NV index of type extend (i.e. an NV index that behaves similar to a PCR).
+
+# OPTIONS
+
+These are the available options:
+
+  * **-i**, **\--data**:
+
+    The data to be extended into the NV space. MUST NOT be NULL.
+
+  * **-p**, **\--nvPath**:
+
+    Identifies the NV space to write. MUST NOT be NULL.
+
+  * **-l**, **\--logData**:
+
+    A JSON representation of data to be written to the PCR’s event log. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvextend --nvPath /nv/Owner/NvExtend --data nv_write_data.file --logData log.data
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     The data to be extended into the NV space. MUST NOT be NULL.
 
-  * **-n**, **\--nvPath**:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to write. MUST NOT be NULL.
 

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -1,0 +1,35 @@
+% tss2_nvincrement(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvincrement**(1) -
+
+# SYNOPSIS
+
+**tss2_nvincrement** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvincrement**(1) - This command increments by 1 an NV index that is of type counter.
+
+# OPTIONS
+
+These are the availabe options:
+
+  * **-n**, **\--nvPath**=:
+
+    Identifies the NV space to increment. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvincrement --nvPath /nv/Owner/myNVcounter
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -1,0 +1,35 @@
+% tss2_nvincrement(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvincrement**(1) -
+
+# SYNOPSIS
+
+**tss2_nvincrement** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvincrement**(1) - This command increments by 1 an NV index that is of type counter.
+
+# OPTIONS
+
+These are the availabe options:
+
+  * **-p**, **\--nvPath**:
+
+    Identifies the NV space to increment. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvincrement --nvPath /nv/Owner/myNVcounter
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -18,7 +18,7 @@
 
 These are the availabe options:
 
-  * **-n**, **\--nvPath**=:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to increment. MUST NOT be NULL.
 

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -1,0 +1,48 @@
+% tss2_nvread(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvread**(1) -
+
+# SYNOPSIS
+
+**tss2_nvread** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvread**(1) - This command reads the entire data from an NV index of the TPM. The FAPI will automatically perform multiple read operations with the TPM if the NV index is larger than the TPM's TPM2_MAX_NV_BUFFER_SIZE.
+
+# OPTIONS
+
+These are the availabe options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-o**, **\--data**:
+
+    Returns the value read from the NV space. MUST NOT be NULL.
+
+  * **-p**, **\--nvPath**:
+
+    Identifies the NV space to read. MUST NOT be NULL.
+
+  * **-l**, **\--logData**:
+
+    Returns the JSON encoded log, if the NV index is of type “extend” and an empty string otherwise. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvread --nvPath /nv/Owner/myNVwrite --data nv_read_data.file
+
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -1,0 +1,48 @@
+% tss2_nvread(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvread**(1) -
+
+# SYNOPSIS
+
+**tss2_nvread** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvread**(1) - This command reads the entire data from an NV index of the TPM. The FAPI will automatically perform multiple read operations with the TPM if the NV index is larger than the TPM's TPM2_MAX_NV_BUFFER_SIZE.
+
+# OPTIONS
+
+These are the availabe options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-d**, **\--data**:
+
+    Returns the value read from the NV space. MUST NOT be NULL.
+
+  * **-n**, **\--nvPath**=:
+
+    Identifies the NV space to read. MUST NOT be NULL.
+
+  * **-l**, **\--logData**=:
+
+    Returns the JSON encoded log, if the NV index is of type “extend” and an empty string otherwise. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvread --nvPath /nv/Owner/myNVwrite --data nv_read_data.file
+
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -22,15 +22,15 @@ These are the availabe options:
 
     Force overwriting the output file.
 
-  * **-d**, **\--data**:
+  * **-o**, **\--data**:
 
     Returns the value read from the NV space. MUST NOT be NULL.
 
-  * **-n**, **\--nvPath**=:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to read. MUST NOT be NULL.
 
-  * **-l**, **\--logData**=:
+  * **-l**, **\--logData**:
 
     Returns the JSON encoded log, if the NV index is of type “extend” and an empty string otherwise. MAY be NULL.
 

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -18,11 +18,11 @@
 
 These are the availabe options:
 
-  * **-b**, **\--bitmap**==\<number\>:
+  * **-i**, **\--bitmap**:
 
     A mask indicating which bits to set in the NV space.
 
-  * **-n**, **\--nvPath**=:
+  * **-p**, **\--nvPath**:
 
     Identifies the NV space to write. MUST NOT be NULL.
 

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -1,0 +1,39 @@
+% tss2_nvsetbits(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvsetbits**(1) -
+
+# SYNOPSIS
+
+**tss2_nvsetbits** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvsetbits**(1) - This command sets bits in an NV Index that was created as a bit field. Any number of bits from 0 to 64 may be SET. The contents of bitmap are ORed with the current contents of the NV Index.
+
+# OPTIONS
+
+These are the availabe options:
+
+  * **-b**, **\--bitmap**==\<number\>:
+
+    A mask indicating which bits to set in the NV space.
+
+  * **-n**, **\--nvPath**=:
+
+    Identifies the NV space to write. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvsetbits --nvPath /nv/Owner/NvBitmap --bitmap 0x0102030405060608
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -1,0 +1,39 @@
+% tss2_nvsetbits(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvsetbits**(1) -
+
+# SYNOPSIS
+
+**tss2_nvsetbits** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvsetbits**(1) - This command sets bits in an NV Index that was created as a bit field. Any number of bits from 0 to 64 may be SET. The contents of bitmap are ORed with the current contents of the NV Index.
+
+# OPTIONS
+
+These are the availabe options:
+
+  * **-i**, **\--bitmap**:
+
+    A mask indicating which bits to set in the NV space.
+
+  * **-p**, **\--nvPath**:
+
+    Identifies the NV space to write. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvsetbits --nvPath /nv/Owner/NvBitmap --bitmap 0x0102030405060608
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     The data to write to the NV space. MUST NOT be NULL.
 
-  * **-n**, **\--nvPath**:
+  * **-p**, **\--nvPath**:
 
-    Identifies the NV space to write. MUST NOT be NULL.
+    Identifies the NV space to write to. MUST NOT be NULL.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -1,0 +1,39 @@
+% tss2_nvwrite(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvwrite**(1) -
+
+# SYNOPSIS
+
+**tss2_nvwrite** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvwrite**(1) - This command writes data to a “regular” (not pin, extend or counter) NV index. Only the full index can be written, partial writes are not allowed. If the provided data is smaller than the NV index’s size, then it is padded up with zero bytes at the end. The FAPI will automatically perform multiple write operations with the TPM if the input buffer is larger than the TPM's TPM2_MAX_NV_BUFFER_SIZE.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-i**, **\--data**:
+
+    The data to write to the NV space. MUST NOT be NULL.
+
+  * **-p**, **\--nvPath**:
+
+    Identifies the NV space to write to. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvwrite --nvPath /nv/Owner/myNV --data data.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -1,0 +1,39 @@
+% tss2_nvwrite(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_nvwrite**(1) -
+
+# SYNOPSIS
+
+**tss2_nvwrite** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_nvwrite**(1) - This command writes data to a “regular” (not pin, extend or counter) NV index. Only the full index can be written, partial writes are not allowed. If the provided data is smaller than the NV index’s size, then it is padded up with zero bytes at the end. The FAPI will automatically perform multiple write operations with the TPM if the input buffer is larger than the TPM's TPM2_MAX_NV_BUFFER_SIZE.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-d**, **\--data**:
+
+    The data to write to the NV space. MUST NOT be NULL.
+
+  * **-n**, **\--nvPath**:
+
+    Identifies the NV space to write. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_nvwrite --nvPath /nv/Owner/myNV --data data.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -1,0 +1,45 @@
+% tss2_pcrextend(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_pcrextend**(1) -
+
+# SYNOPSIS
+
+**tss2_pcrextend** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_pcrextend**(1) - This command extends the data into the PCR listed. The parameter logData is extended into the PCR log. If the logData is NULL, only the PCR extend takes place. All PCRs currently active in the TPM are extended, see
+TPM2_PCR_Event.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-x**, **\--pcr**:
+
+   The PCR to extend.
+
+  * **-i**, **\--data**:
+
+    The event data. Note that this data will be hashed using the respective PCR’s hash algorithm. See the TPM2_PCR_Event function of the TPM specification. MUST NOT be NULL.
+
+  * **-l**, **\--logData**:
+
+    Contains a JSON representation of data to be written to the PCR’s event log. MAY be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_pcrextend --pcr 16 --data pcr_event_data.file --logData pcr_log_write.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -19,11 +19,11 @@ TPM2_PCR_Event.
 
 These are the available options:
 
-  * **-c**, **\--pcr**:
+  * **-x**, **\--pcr**:
 
    The PCR to extend.
 
-  * **-d**, **\--data**:
+  * **-i**, **\--data**:
 
     The event data. Note that this data will be hashed using the respective PCR’s hash algorithm. See the TPM2_PCR_Event function of the TPM specification. MUST NOT be NULL.
 

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -1,0 +1,45 @@
+% tss2_pcrextend(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_pcrextend**(1) -
+
+# SYNOPSIS
+
+**tss2_pcrextend** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_pcrextend**(1) - This command extends the data into the PCR listed. The parameter logData is extended into the PCR log. If the logData is NULL, only the PCR extend takes place. All PCRs currently active in the TPM are extended, see
+TPM2_PCR_Event.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-c**, **\--pcr**:
+
+   The PCR to extend.
+
+  * **-d**, **\--data**:
+
+    The event data. Note that this data will be hashed using the respective PCR’s hash algorithm. See the TPM2_PCR_Event function of the TPM specification. MUST NOT be NULL.
+
+  * **-l**, **\--logData**:
+
+    Contains a JSON representation of data to be written to the PCR’s event log. MAY be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_pcrextend --pcr 16 --data pcr_event_data.file --logData pcr_log_write.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -1,0 +1,47 @@
+% tss2_pcrread(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_pcrread**(1) -
+
+# SYNOPSIS
+
+**tss2_pcrread** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_pcrread**(1) - This command provides a PCRs value and corresponding Event log. The PCR bank to be used per PCR is defined in the cryptographic profile.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-c**, **\--pcrValue**:
+
+    Returns PCR digest. MAY be NULL.
+
+  * **-i**, **\--pcrIndex**:
+
+    Identifies the PCR to read.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output files.
+
+  * **-l**, **\--pcrLog**:
+
+    Returns the PCR log for that PCR in the format defined in the FAPI specification. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_pcrread --pcrIndex 16 --pcrValue pcr_digest.file --pcrLog pcr_log_read.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -1,0 +1,47 @@
+% tss2_pcrread(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_pcrread**(1) -
+
+# SYNOPSIS
+
+**tss2_pcrread** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_pcrread**(1) - This command provides a PCRs value and corresponding Event log. The PCR bank to be used per PCR is defined in the cryptographic profile.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-o**, **\--pcrValue**:
+
+    Returns PCR digest. MAY be NULL.
+
+  * **-x**, **\--pcrIndex**:
+
+    Identifies the PCR to read.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output files.
+
+  * **-l**, **\--pcrLog**:
+
+    Returns the PCR log for that PCR in the format defined in the FAPI specification. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_pcrread --pcrIndex 16 --pcrValue pcr_digest.file --pcrLog pcr_log_read.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-c**, **\--pcrValue**:
+  * **-o**, **\--pcrValue**:
 
     Returns PCR digest. MAY be NULL.
 
-  * **-i**, **\--pcrIndex**:
+  * **-x**, **\--pcrIndex**:
 
     Identifies the PCR to read.
 

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -26,13 +26,13 @@ without authorization value is made persistent.
 
 These are the available options:
 
-  * **-e**, **\--authValueEh**=:
+  * **-E**, **\--authValueEh**:
     The authorization value for the privacy admin, i.e. the endorsement hierarchy. MAY be NULL.
 
-  * **-s**, **\--authValueSh**=:
+  * **-S**, **\--authValueSh**:
     The authorization value for the owner, i.e. the storage hierarchy. SHOULD be NULL.
 
-  * **-l**, **\--authValueLockout**=:
+  * **-L**, **\--authValueLockout**:
     The authorization value for the lockout authorization. SHOULD NOT be NULL.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -1,0 +1,50 @@
+% tss2_provision(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_provision**(1) -
+
+# SYNOPSIS
+
+**tss2_provision** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_provision**(1) - This command provisions a FAPI instance and its associated TPM. The steps taken SHALL be:
+
+  * Retrieve the EK template, nonce and certificate, verify that they match the TPM’s EK and store them in the key store.
+  * Set the authValues and policies for the Owner (Storage Hierarchy), the Privacy Administrator (Endorsement Hierarchy) and the lockout authority.
+  * Scan the TPM’s nv indices and create entries in the metadata store. This operation MAY use a heuristic to guess the originating programs for nv indices found and name the entries accordingly.
+  * Create the SRK (storage primary key) inside the TPM and make it persistent if required by the FAPI configuration and stored its metadata in the system-wide metadata store. Note that the SRK will not have an authorization value associated.
+
+If an authorization value is associated with the storage hierarchy, it is highly RECOMMENDED that the SRK
+without authorization value is made persistent.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-E**, **\--authValueEh**:
+    The authorization value for the privacy admin, i.e. the endorsement hierarchy. MAY be NULL.
+
+  * **-S**, **\--authValueSh**:
+    The authorization value for the owner, i.e. the storage hierarchy. SHOULD be NULL.
+
+  * **-L**, **\--authValueLockout**:
+    The authorization value for the lockout authorization. SHOULD NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_provision
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -1,0 +1,50 @@
+% tss2_provision(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_provision**(1) -
+
+# SYNOPSIS
+
+**tss2_provision** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_provision**(1) - This command provisions a FAPI instance and its associated TPM. The steps taken SHALL be:
+
+  * Retrieve the EK template, nonce and certificate, verify that they match the TPM’s EK and store them in the key store.
+  * Set the authValues and policies for the Owner (Storage Hierarchy), the Privacy Administrator (Endorsement Hierarchy) and the lockout authority.
+  * Scan the TPM’s nv indices and create entries in the metadata store. This operation MAY use a heuristic to guess the originating programs for nv indices found and name the entries accordingly.
+  * Create the SRK (storage primary key) inside the TPM and make it persistent if required by the FAPI configuration and stored its metadata in the system-wide metadata store. Note that the SRK will not have an authorization value associated.
+
+If an authorization value is associated with the storage hierarchy, it is highly RECOMMENDED that the SRK
+without authorization value is made persistent.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-e**, **\--authValueEh**=:
+    The authorization value for the privacy admin, i.e. the endorsement hierarchy. MAY be NULL.
+
+  * **-s**, **\--authValueSh**=:
+    The authorization value for the owner, i.e. the storage hierarchy. SHOULD be NULL.
+
+  * **-l**, **\--authValueLockout**=:
+    The authorization value for the lockout authorization. SHOULD NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_provision
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-L**, **\--pcrList**:
+  * **-x**, **\--pcrList**:
 
     An array holding the PCR indices to quote against. MUST NOT be NULL.
 
-  * **-d**, **\--qualifyingData**:
+  * **-Q**, **\--qualifyingData**:
 
     A nonce provided by the caller to ensure freshness of the signature. MAY be
     NULL.
@@ -35,7 +35,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     Identifies the signing key. MUST NOT be NULL.
 
@@ -43,7 +43,7 @@ These are the available options:
 
     Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
 
-  * **-s**, **\--signature**:
+  * **-o**, **\--signature**:
 
     Returns the signature over the quoted material. MUST NOT be NULL.
 

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -1,0 +1,64 @@
+% tss2_quote(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_quote**(1) -
+
+# SYNOPSIS
+
+**tss2_quote** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_quote**(1) - This command performs an attestation using the TPM. The PCR bank for each provided PCR index is set in the cryptographic profile.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-x**, **\--pcrList**:
+
+    An array holding the PCR indices to quote against. MUST NOT be NULL.
+
+  * **-Q**, **\--qualifyingData**:
+
+    A nonce provided by the caller to ensure freshness of the signature. MAY be
+    NULL.
+
+  * **-l**, **\--pcrLog**:
+
+    Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--keyPath**:
+
+    Identifies the signing key. MUST NOT be NULL.
+
+  * **-q**, **\--quoteInfo**:
+
+    Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
+
+  * **-o**, **\--signature**:
+
+    Returns the signature over the quoted material. MUST NOT be NULL.
+
+  * **-c**, **\--certificate**:
+
+    The certificate associated with keyPath in PEM format. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_quote --keyPath HS/SRK/quotekey --pcrList "16" --qualifyingData nonce.file --signature signature.file --pcrLog pcr.log --certificate certificate.file --quoteInfo quote.info
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -1,0 +1,64 @@
+% tss2_quote(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_quote**(1) -
+
+# SYNOPSIS
+
+**tss2_quote** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_quote**(1) - This command performs an attestation using the TPM. The PCR bank for each provided PCR index is set in the cryptographic profile.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-L**, **\--pcrList**:
+
+    An array holding the PCR indices to quote against. MUST NOT be NULL.
+
+  * **-d**, **\--qualifyingData**:
+
+    A nonce provided by the caller to ensure freshness of the signature. MAY be
+    NULL.
+
+  * **-l**, **\--pcrLog**:
+
+    Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-k**, **\--keyPath**=:
+
+    Identifies the signing key. MUST NOT be NULL.
+
+  * **-q**, **\--quoteInfo**:
+
+    Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
+
+  * **-s**, **\--signature**:
+
+    Returns the signature over the quoted material. MUST NOT be NULL.
+
+  * **-c**, **\--certificate**:
+
+    The certificate associated with keyPath in PEM format. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_quote --keyPath HS/SRK/quotekey --pcrList "16" --qualifyingData nonce.file --signature signature.file --pcrLog pcr.log --certificate certificate.file --quoteInfo quote.info
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -1,0 +1,41 @@
+% tss2_setappdata(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_setappdata**(1)
+
+# SYNOPSIS
+
+**tss2_setappdata** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_setappdata**(1) - allows an application to associate an arbitrary data blob with a given object. The data SHALL be stored and the same data SHALL be returned upon Fapi_GetAppData. Previously stored data SHALL be overwritten by this function. If NULL is passed in, stored data SHALL be deleted.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    Path of the object for which the appData will be stored. MUST NOT be NULL.
+
+  * **-a**, **\--appData**=:
+
+    The data to be stored. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_setappdata --path HS/SRK/myRSACrypt --appData appData
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -1,0 +1,41 @@
+% tss2_setappdata(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_setappdata**(1)
+
+# SYNOPSIS
+
+**tss2_setappdata** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_setappdata**(1) - allows an application to associate an arbitrary data blob with a given object. The data SHALL be stored and the same data SHALL be returned upon Fapi_GetAppData. Previously stored data SHALL be overwritten by this function. If NULL is passed in, stored data SHALL be deleted.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    Path of the object for which the appData will be stored. MUST NOT be NULL.
+
+  * **-i**, **\--appData**:
+
+    The data to be stored. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+```
+tss2_setappdata --path HS/SRK/myRSACrypt --appData appData
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     Path of the object for which the appData will be stored. MUST NOT be NULL.
 
-  * **-a**, **\--appData**=:
+  * **-i**, **\--appData**:
 
     The data to be stored. MAY be NULL.
 

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -1,0 +1,39 @@
+% tss2_setcertificate(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_setcertificate**(1) -
+
+# SYNOPSIS
+
+**tss2_setcertificate** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_setcertificate**(1) - This command associates an x509 certificate in PEM encoding into the path of a key.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**:
+
+    Identifies the entity to be associated with the certificate. MUST NOT be NULL.
+
+  * **-i**, **\--x509certData**:
+
+    The PEM encoded certificate. MAY be NULL. If x509certData is NULL then the stored x509 certificate SHALL be removed.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_setcertificate --path HS/SRK/myRSACrypt --x509certData certificate.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     Identifies the entity to be associated with the certificate. MUST NOT be NULL.
 
-  * **-x**, **\--x509certData**:
+  * **-i**, **\--x509certData**:
 
     The PEM encoded certificate. MAY be NULL. If x509certData is NULL then the stored x509 certificate SHALL be removed.
 

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -1,0 +1,39 @@
+% tss2_setcertificate(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_setcertificate**(1) -
+
+# SYNOPSIS
+
+**tss2_setcertificate** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_setcertificate**(1) - This command associates an x509 certificate in PEM encoding into the path of a key.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--path**=:
+
+    Identifies the entity to be associated with the certificate. MUST NOT be NULL.
+
+  * **-x**, **\--x509certData**:
+
+    The PEM encoded certificate. MAY be NULL. If x509certData is NULL then the stored x509 certificate SHALL be removed.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_setcertificate --path HS/SRK/myRSACrypt --x509certData certificate.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -1,0 +1,41 @@
+% tss2_setdescription(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_setdescription**(1)
+
+# SYNOPSIS
+
+**tss2_setdescription** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_setdescription**(1) - This command allows an application to assign a human readable description to an object in the metadata store. Previously stored descriptions SHALL be overwritten by this function. If NULL is passed in, any stored description SHALL be deleted.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-i**, **\--description**:
+
+    The data to be stored as description for the object. MAY be NULL.
+
+  * **-p**, **\--path**:
+
+    The path of the object for which the description will be stored. MUST NOT be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+```
+tss2_setdescription --path HS/SRK --description object-description
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-d**, **\--description**:
+  * **-i**, **\--description**:
 
     The data to be stored as description for the object. MAY be NULL.
 
-  * **-p**, **\--path**=:
+  * **-p**, **\--path**:
 
     The path of the object for which the description will be stored. MUST NOT be NULL.
 

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -1,0 +1,41 @@
+% tss2_setdescription(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_setdescription**(1)
+
+# SYNOPSIS
+
+**tss2_setdescription** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_setdescription**(1) - This command allows an application to assign a human readable description to an object in the metadata store. Previously stored descriptions SHALL be overwritten by this function. If NULL is passed in, any stored description SHALL be deleted.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-d**, **\--description**:
+
+    The data to be stored as description for the object. MAY be NULL.
+
+  * **-p**, **\--path**=:
+
+    The path of the object for which the description will be stored. MUST NOT be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+```
+tss2_setdescription --path HS/SRK --description object-description
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -1,0 +1,59 @@
+% tss2_sign(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_sign**(1) -
+
+# SYNOPSIS
+
+**tss2_sign** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_sign**(1) - This command uses a key inside the TPM to sign a digest value.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-k**, **\--keyPath**=:
+
+    The path to the signing key. MUST NOT be NULL.
+
+  * **-P**, **\--padding**:
+
+    The padding algorithm used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
+
+  * **-c**, **\--certificate**:
+
+    The certificate associated with keyPath in PEM format. MAY be NULL.
+
+  * **-d**, **\--digest**:
+
+    The data to be signed, already hashed. MUST NOT be NULL.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--publicKey**:
+
+    The public key associated with keyPath in PEM format. MAY be NULL.
+
+  * **-s**, **\--signature**:
+
+    Returns the signature in binary form. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_sign --keyPath HS/SRK/myRSASign --padding "RSA_PSS" --digest digest.file --signature signature.file --publicKey public_key.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -1,0 +1,59 @@
+% tss2_sign(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_sign**(1) -
+
+# SYNOPSIS
+
+**tss2_sign** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_sign**(1) - This command uses a key inside the TPM to sign a digest value.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--keyPath**:
+
+    The path to the signing key. MUST NOT be NULL.
+
+  * **-s**, **\--padding**:
+
+    The padding scheme used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
+
+  * **-c**, **\--certificate**:
+
+    The certificate associated with keyPath in PEM format. MAY be NULL.
+
+  * **-d**, **\--digest**:
+
+    The data to be signed, already hashed. MUST NOT be NULL.
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-k**, **\--publicKey**:
+
+    The public key associated with keyPath in PEM format. MAY be NULL.
+
+  * **-o**, **\--signature**:
+
+    Returns the signature in binary form. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_sign --keyPath HS/SRK/myRSASign --padding "RSA_PSS" --digest digest.file --signature signature.file --publicKey public_key.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-k**, **\--keyPath**=:
+  * **-p**, **\--keyPath**:
 
     The path to the signing key. MUST NOT be NULL.
 
-  * **-P**, **\--padding**:
+  * **-s**, **\--padding**:
 
-    The padding algorithm used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
+    The padding scheme used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
 
   * **-c**, **\--certificate**:
 
@@ -38,11 +38,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--publicKey**:
+  * **-k**, **\--publicKey**:
 
     The public key associated with keyPath in PEM format. MAY be NULL.
 
-  * **-s**, **\--signature**:
+  * **-o**, **\--signature**:
 
     Returns the signature in binary form. MUST NOT be NULL.
 

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -1,0 +1,43 @@
+% tss2_unseal(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_unseal**(1) -
+
+# SYNOPSIS
+
+**tss2_unseal** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_unseal**(1) - This command unseals data from a seal in the FAPI meta data store.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
+
+    Path of the object for which the blobs will be returned. MUST NOT be NULL.
+
+  * **-o**, **\--data**:
+
+    The decrypted data after unsealing. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_unseal --path HS/SRK/myRSACrypt --data unsealed.data
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -26,7 +26,7 @@ These are the available options:
 
     Path of the object for which the blobs will be returned. MUST NOT be NULL.
 
-  * **-d**, **\--data**:
+  * **-o**, **\--data**:
 
     The decrypted data after unsealing. MAY be NULL.
 

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -1,0 +1,43 @@
+% tss2_unseal(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_unseal**(1) -
+
+# SYNOPSIS
+
+**tss2_unseal** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_unseal**(1) - This command unseals data from a seal in the FAPI meta data store.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**:
+
+    Path of the object for which the blobs will be returned. MUST NOT be NULL.
+
+  * **-d**, **\--data**:
+
+    The decrypted data after unsealing. MAY be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_unseal --path HS/SRK/myRSACrypt --data unsealed.data
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -1,0 +1,59 @@
+% tss2_verifyquote(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_verifyquote**(1) -
+
+# SYNOPSIS
+
+**tss2_verifyquote** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_verifyquote**(1) - This command verifies that the data returned by a quote is valid. This includes
+
+  * Reconstructing the quoteInfo’s PCR values from the eventLog (if an eventLog was provided)
+  * Verifying the quoteInfo using the signature and the publicKeyPath
+
+An application using Fapi_VerifyQuote() will further have to
+
+* Assess the publicKey’s trustworthiness
+* Assess the eventLog entries’ trustworthiness
+
+# OPTIONS
+
+These are the available options:
+
+  * **-q**, **\--qualifyingData**:
+
+    A nonce provided by the caller to ensure freshness of the signature. MAY be NULL.
+
+  * **-l**, **\--pcrLog**:
+
+    Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
+
+  * **-i**, **\--quoteInfo**:
+
+    The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
+
+  * **-p**, **\--publicKeyPath**=:
+
+    Identifies the signing key. MUST NOT be NULL. MAY be a path to the public key hierarchy /ext.
+
+  * **-s**, **\--signature**:
+
+    The signature over the quoted material. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+    tss2_verifyquote --publicKeyPath "ext/myNewParent" --qualifyingData nonce.file --quoteInfo quote.info --signature signature.file --pcrLog pcr.log
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -1,0 +1,59 @@
+% tss2_verifyquote(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_verifyquote**(1) -
+
+# SYNOPSIS
+
+**tss2_verifyquote** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_verifyquote**(1) - This command verifies that the data returned by a quote is valid. This includes
+
+  * Reconstructing the quoteInfo’s PCR values from the eventLog (if an eventLog was provided)
+  * Verifying the quoteInfo using the signature and the publicKeyPath
+
+An application using Fapi_VerifyQuote() will further have to
+
+* Assess the publicKey’s trustworthiness
+* Assess the eventLog entries’ trustworthiness
+
+# OPTIONS
+
+These are the available options:
+
+  * **-Q**, **\--qualifyingData**:
+
+    A nonce provided by the caller to ensure freshness of the signature. MAY be NULL.
+
+  * **-l**, **\--pcrLog**:
+
+    Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
+
+  * **-q**, **\--quoteInfo**:
+
+    The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
+
+  * **-k**, **\--publicKeyPath**:
+
+    Identifies the signing key. MUST NOT be NULL. MAY be a path to the public key hierarchy /ext.
+
+  * **-i**, **\--signature**:
+
+    The signature over the quoted material. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+    tss2_verifyquote --publicKeyPath "ext/myNewParent" --qualifyingData nonce.file --quoteInfo quote.info --signature signature.file --pcrLog pcr.log
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -26,7 +26,7 @@ An application using Fapi_VerifyQuote() will further have to
 
 These are the available options:
 
-  * **-q**, **\--qualifyingData**:
+  * **-Q**, **\--qualifyingData**:
 
     A nonce provided by the caller to ensure freshness of the signature. MAY be NULL.
 
@@ -34,15 +34,15 @@ These are the available options:
 
     Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
 
-  * **-i**, **\--quoteInfo**:
+  * **-q**, **\--quoteInfo**:
 
     The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
 
-  * **-p**, **\--publicKeyPath**=:
+  * **-k**, **\--publicKeyPath**:
 
     Identifies the signing key. MUST NOT be NULL. MAY be a path to the public key hierarchy /ext.
 
-  * **-s**, **\--signature**:
+  * **-i**, **\--signature**:
 
     The signature over the quoted material. MUST NOT be NULL.
 

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     The data that was signed, already hashed. MUST NOT be NULL
 
-  * **-k**, **\--keyPath**:
+  * **-p**, **\--keyPath**:
 
     Path to the verification public key. MUST NOT be NULL.
 
-  * **-s**, **\--signature**:
+  * **-i**, **\--signature**:
 
     The signature to be verified. MUST NOT be NULL.
 

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -1,0 +1,44 @@
+% tss2_verifysignature(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_verifysignature**(1) -
+
+# SYNOPSIS
+
+**tss2_verifysignature** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_verifysignature**(1) - This command verifies a signature using a public key found in a keyPath. This function MAY or MAY NOT use the TPM for this operation.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-d**, **\--digest**:
+
+    The data that was signed, already hashed. MUST NOT be NULL
+
+  * **-k**, **\--keyPath**:
+
+    Path to the verification public key. MUST NOT be NULL.
+
+  * **-s**, **\--signature**:
+
+    The signature to be verified. MUST NOT be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_verifysignature --keyPath ext/myRSASign --digest digest.file --signature signature.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -1,0 +1,44 @@
+% tss2_verifysignature(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_verifysignature**(1) -
+
+# SYNOPSIS
+
+**tss2_verifysignature** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_verifysignature**(1) - This command verifies a signature using a public key found in a keyPath. This function MAY or MAY NOT use the TPM for this operation.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-d**, **\--digest**:
+
+    The data that was signed, already hashed. MUST NOT be NULL
+
+  * **-p**, **\--keyPath**:
+
+    Path to the verification public key. MUST NOT be NULL.
+
+  * **-i**, **\--signature**:
+
+    The signature to be verified. MUST NOT be NULL.
+
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_verifysignature --keyPath ext/myRSASign --digest digest.file --signature signature.file
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -1,0 +1,39 @@
+% tss2_writeauthorizenv(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_writeauthorizenv**(1) -
+
+# SYNOPSIS
+
+**tss2_writeauthorizenv** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_writeauthorizenv**(1) - This command writes the digest value of a policy to an NV index such that this policy can be used in other policies containing a corresponding PolicyAuthorizeNv element. Note that the nameAlg property of the NV index defines the digest algorithm for the policy.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-n**, **\--nvPath**:
+
+    The path of the NV index. MUST NOT be NULL.
+
+  * **-l**, **\--policyPath**=:
+
+    The path of the new policy. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_writeauthorizenv --nvPath /nv/Owner/myNV --policyPath pcr-policy
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -1,0 +1,39 @@
+% tss2_writeauthorizenv(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_writeauthorizenv**(1) -
+
+# SYNOPSIS
+
+**tss2_writeauthorizenv** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tss2_writeauthorizenv**(1) - This command writes the digest value of a policy to an NV index such that this policy can be used in other policies containing a corresponding PolicyAuthorizeNv element. Note that the nameAlg property of the NV index defines the digest algorithm for the policy.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-p**, **\--nvPath**:
+
+    The path of the NV index. MUST NOT be NULL.
+
+  * **-P**, **\--policyPath**:
+
+    The path of the new policy. MUST NOT be NULL.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLE
+
+tss2_writeauthorizenv --nvPath /nv/Owner/myNV --policyPath pcr-policy
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-n**, **\--nvPath**:
+  * **-p**, **\--nvPath**:
 
     The path of the NV index. MUST NOT be NULL.
 
-  * **-l**, **\--policyPath**=:
+  * **-P**, **\--policyPath**:
 
     The path of the new policy. MUST NOT be NULL.
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -15,7 +15,7 @@ For example:
 To add a new test, do:
 
 1. add a script to the integration directory.
-2. source helper.sh in the new script.
+2. source helpers.sh in the new script.
 4. issue the command start_up.
 5. Do whatever test you need to do.
 6. If you set the EXIT handler, call tpm2_shutdown in that handler.

--- a/test/integration/fapi/fapi-authorize-policy.sh
+++ b/test/integration/fapi/fapi-authorize-policy.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/mySignKey
+POLICY_SIGN_KEY_PATH=HS/SRK/myPolicySignKey
+PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+AUTHORIZE_POLICY_DATA=$TEMP_DIR/pol_authorize_ref.json
+POLICY_PCR=policy/pcr-policy
+POLICY_AUTHORIZE=policy/authorize-policy
+POLICY_REF=$TEMP_DIR/policy_ref.file
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
+DIGEST_FILE=$TEMP_DIR/digest.file
+
+echo -n 01234567890123456789012345678901 > $DIGEST_FILE
+echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
+
+tss2_provision
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+
+tss2_import --path $POLICY_AUTHORIZE --importData $AUTHORIZE_POLICY_DATA
+
+tss2_createkey --path $POLICY_SIGN_KEY_PATH --type "noDa, sign"
+
+tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH --policyPath $POLICY_PCR \
+    --policyRef $POLICY_REF
+
+tss2_createkey --path $KEY_PATH --type "noDa, sign" \
+    --policyPath $POLICY_AUTHORIZE
+
+tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+
+
+expect <<EOF
+# Try with missing policyPath
+spawn tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH \
+    --policyRef $POLICY_REF
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing keyPath
+spawn tss2_authorizepolicy \
+    --policyPath $POLICY_PCR --policyRef $POLICY_REF
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-branch-select.sh
+++ b/test/integration/fapi/fapi-branch-select.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH="HS/SRK/mySignKey"
+POLICY_SIGN_KEY_PATH="HS/SRK/myPolicySignKey"
+PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+AUTHORIZE_POLICY_DATA=$TEMP_DIR/pol_authorize.json
+POLICY_PCR=policy/pcr-policy
+POLICY_PCR2=policy/pcr-policy2
+POLICY_AUTHORIZE=policy/authorize-policy
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
+DIGEST_FILE=$TEMP_DIR/digest.file
+echo -n 01234567890123456789012345678901 > $DIGEST_FILE
+
+POLICY_REF=$TEMP_DIR/policy_ref.file
+echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
+
+tss2_provision
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+
+tss2_import --path $POLICY_PCR2 --importData $PCR_POLICY_DATA
+
+tss2_import --path $POLICY_AUTHORIZE --importData $AUTHORIZE_POLICY_DATA
+
+tss2_createkey --path $POLICY_SIGN_KEY_PATH --type "noDa, sign"
+
+tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH --policyPath $POLICY_PCR \
+    --policyRef $POLICY_REF
+
+tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH --policyPath $POLICY_PCR2 \
+    --policyRef $POLICY_REF
+
+tss2_createkey --path $KEY_PATH --type "noDa, sign" \
+    --policyPath $POLICY_AUTHORIZE
+
+expect <<EOF
+# Check if system asks for branch selection
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+expect {
+    "Your choice: " {
+    } eof {
+        send_user "The system has not asked for branch selection\n"
+        exit 1
+    }
+    }
+    send "1\r"
+    set ret [wait]
+    if {[lindex \$ret 2]} {
+        send_user "Command failed\n"
+        exit 1
+    }
+EOF
+
+expect <<EOF
+# Selecting wrong branch
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+expect {
+    "Your choice: " {
+    } eof {
+        send_user "The system has not asked for branch selection\n"
+        exit 1
+    }
+}
+send "4\r"
+expect {
+    "The entered integer must be positive and less than 3." {
+    } eof {
+        send_user "The system has not responded as expected\n"
+        exit 1
+    }
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+PLAIN_TEXT=$TEMP_DIR/plaintext.file
+KEY_PATH="HS/SRK/myRSACrypt"
+ENCRYPTED_FILE=$TEMP_DIR/encrypted.file
+DECRYPTED_FILE=$TEMP_DIR/decrypted.file
+PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+POLICY_PCR=policy/pcr-policy
+
+echo -n "Secret Text!" > $PLAIN_TEXT
+
+tss2_provision
+
+expect <<EOF
+# Try 2 different passwords
+spawn tss2_createkey --path $KEY_PATH --type "noDa, decrypt" --authValue
+expect "Password: "
+send "1\r"
+expect "Retype password: "
+send "2\r"
+expect {
+    "Passwords do not match" {
+            } eof {
+                send_user "Expected password mismatch, but got nothing, or
+                rather EOF\n"
+                exit 1
+            }
+        }
+        set ret [wait]
+        if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+            send_user "Using -P with different passwords on the prompt has not failed\n"
+            exit 1
+        }
+EOF
+
+expect <<EOF
+# Try with missing path
+spawn tss2_createkey --type "noDa, decrypt" --authValue=abc
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing type
+spawn tss2_createkey --path $KEY_PATH --authValue=abc
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+
+tss2_createkey --path $KEY_PATH --type "noDa, decrypt"
+
+tss2_encrypt --keyPath $KEY_PATH --plainText $PLAIN_TEXT \
+    --cipherText $ENCRYPTED_FILE --force
+
+expect <<EOF
+# Try with missing keypath
+spawn tss2_encrypt --plainText $PLAIN_TEXT --cipherText $ENCRYPTED_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing plaintext
+spawn tss2_encrypt --keyPath $KEY_PATH --cipherText $ENCRYPTED_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing ciphertext
+spawn tss2_encrypt --keyPath $KEY_PATH --plainText $PLAIN_TEXT
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong plaintext file
+spawn tss2_encrypt --keyPath $KEY_PATH --plainText abc \
+    --cipherText $ENCRYPTED_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing ciphertext
+spawn tss2_decrypt --keyPath $KEY_PATH --plainText $DECRYPTED_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing plaintext
+spawn tss2_decrypt --keyPath $KEY_PATH --cipherText $ENCRYPTED_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing keyPath
+spawn tss2_decrypt --cipherText $ENCRYPTED_FILE --plainText $DECRYPTED_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+tss2_decrypt --keyPath $KEY_PATH --cipherText $ENCRYPTED_FILE \
+    --plainText $DECRYPTED_FILE --force
+
+
+if [ "`cat $DECRYPTED_FILE`" != "`cat $PLAIN_TEXT`" ]; then
+  echo "Encryption/Decryption failed"
+  exit 1
+fi
+
+exit 0

--- a/test/integration/fapi/fapi-export-key.sh
+++ b/test/integration/fapi/fapi-export-key.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH="HS/SRK/myRSADecrypt"
+KEY_PATH_PARENT="HS/SRK/myParent"
+JSON_POLICY=$TEMP_DIR/pol_duplicate.json
+DUPLICATE_POLICY=policy/duplicate-policy
+EXPORTED_KEY=$TEMP_DIR/exportedKey
+EXPORTED_PARENT_KEY=$TEMP_DIR/exportedParentKey
+LOADED_KEY="myNewParent"
+
+tss2_provision
+
+tss2_import --path $DUPLICATE_POLICY --importData $JSON_POLICY
+
+expect <<EOF
+# Try with missing path
+spawn tss2_import --importData $JSON_POLICY
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing importData
+spawn tss2_import --path $DUPLICATE_POLICY
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+tss2_createkey --path $KEY_PATH_PARENT --type "restricted, decrypt, noDA"
+
+tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH_PARENT \
+    --exportedData $EXPORTED_PARENT_KEY --force
+
+tss2_import --path "ext/$LOADED_KEY" --importData $EXPORTED_PARENT_KEY
+
+tss2_createkey --path $KEY_PATH --type "noDa, exportable, decrypt" \
+    --policyPath $DUPLICATE_POLICY
+
+tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
+    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" --exportedData $EXPORTED_KEY
+
+expect <<EOF
+# Try with missing exportedData
+spawn tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
+    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing pathOfKeyToDuplicate
+spawn tss2_exportkey --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" \
+    --exportedData $EXPORTED_KEY
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try to fail command
+spawn tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
+    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" --exportedData
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try to fail writing to output
+spawn tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
+    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" --exportedData $EXPORTED_KEY
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-export-policy.sh
+++ b/test/integration/fapi/fapi-export-policy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH="HS/SRK/myRSASign"
+POLICY_NAME=policy_pcr
+POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+JSON_POLICY=policy/pcr-policy
+EXPORTED_POLICY=$TEMP_DIR/exported-pcr-policy
+
+tss2_provision
+
+tss2_import --path $JSON_POLICY --importData $POLICY_DATA
+
+tss2_createkey --path $KEY_PATH --type "noDa, sign" --policyPath $JSON_POLICY
+
+tss2_exportpolicy --path $KEY_PATH --jsonPolicy $EXPORTED_POLICY --force
+
+if [ ! -s $EXPORTED_POLICY ]
+then
+     echo "Exported policy is empty"
+     exit 1
+fi
+
+expect <<EOF
+# Try with missing path
+spawn tss2_exportpolicy --jsonPolicy $EXPORTED_POLICY
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing jsonPolicy
+spawn tss2_exportpolicy --path $KEY_PATH
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-get-info.sh
+++ b/test/integration/fapi/fapi-get-info.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+DATA_OUTPUT_FILE=$TEMP_DIR/output.file
+
+tss2_provision
+
+tss2_getinfo --info $DATA_OUTPUT_FILE --force
+
+if [ ! -s $DATA_OUTPUT_FILE ]
+then
+     echo "File is empty"
+     exit 1
+fi
+
+expect <<EOF
+# Try with missing info file
+spawn tss2_getinfo --info $DATA_OUTPUT_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-get-platform-certificates.sh
+++ b/test/integration/fapi/fapi-get-platform-certificates.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+PATH=${BUILDDIR}/tools/fapi:$PATH
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+CERTIFICATES_OUTPUT_FILE=$TEMP_DIR/certificates_output.file
+
+tss2_provision
+
+expect <<EOF
+# Try with missing certificates
+spawn tss2_getplatformcertificates
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try normal command; should fail since no certificates present
+spawn tss2_getplatformcertificates --certificates $CERTIFICATES_OUTPUT_FILE \
+    --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-get-random.sh
+++ b/test/integration/fapi/fapi-get-random.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+PATH=${BUILDDIR}/tools/fapi:$PATH
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+OUTPUT_FILE="$TEMP_DIR/output.file"
+
+tss2_provision
+
+expect <<EOF
+# Try with wrong size value
+spawn tss2_getrandom --numBytes a --data $OUTPUT_FILE --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing output
+spawn tss2_getrandom --numBytes 20
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-get-tpm-blobs.sh
+++ b/test/integration/fapi/fapi-get-tpm-blobs.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH="HS/SRK/myRSASign"
+PUBLIC_KEY_FILE=$TEMP_DIR/pub_key.file
+PRIVATE_KEY_FILE=$TEMP_DIR/priv_key.file
+POLICY_FILE=$TEMP_DIR/policy.file
+PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+POLICY_PCR=policy/pcr-policy
+
+tss2_provision
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+
+tss2_createkey --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa, sign"
+
+tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
+    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE --force
+
+expect <<EOF
+# Try with missing path
+spawn tss2_gettpmblobs --tpm2bPublic $PUBLIC_KEY_FILE \
+    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing tpm2bPublic
+spawn tss2_gettpmblobs --path $KEY_PATH \
+    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing tpm2bPrivate
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
+    --policy $POLICY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing policy
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
+    --tpm2bPrivate $PRIVATE_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with existing directory PUBLIC_KEY_FILE
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
+    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+
+
+exit 0

--- a/test/integration/fapi/fapi-key-change-auth.sh
+++ b/test/integration/fapi/fapi-key-change-auth.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+PW=abc
+KEY_PATH=HS/SRK/myRSASign
+DIGEST_FILE=$TEMP_DIR/digest.file
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
+IMPORTED_KEY_NAME=importedPubKey
+
+tss2_provision
+echo 0123456789012345678 > $DIGEST_FILE
+tss2_createkey --path $KEY_PATH --type "noDa, sign"
+tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+
+expect <<EOF
+# Try 2 different passwords
+spawn tss2_changeauth --entityPath $KEY_PATH --authValue
+expect "Password: "
+send "1\r"
+expect "Retype password: "
+send "2\r"
+expect {
+    "Passwords do not match" {
+            } eof {
+                send_user "Expected password mismatch, but got nothing, or
+                rather EOF\n"
+                exit 1
+            }
+        }
+        set ret [wait]
+        if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+            send_user "Using -P with different passwords on the prompt has not failed\n"
+            exit 1
+        }
+EOF
+
+tss2_changeauth --entityPath $KEY_PATH --authValue=$PW
+
+expect <<EOF
+# Check if system asks for auth value
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE --force
+expect {
+    "Authorize object: " {
+    } eof {
+        send_user "The system has not asked for password\n"
+        exit 1
+    }
+    }
+    send "$PW\r"
+    set ret [wait]
+    if {[lindex \$ret 2] || [lindex \$ret 3]} {
+        send_user "Passing password has failed\n"
+        exit 1
+    }
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-list.sh
+++ b/test/integration/fapi/fapi-list.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/myRSASign
+
+tss2_provision
+
+tss2_createkey --path $KEY_PATH --type "noDa, sign"
+
+tss2_list
+
+PROFILE_NAME=$( tss2_list --searchPath= --pathList=- | cut -d "/" -f2 )
+SIGN_OBJECT=/$PROFILE_NAME/$KEY_PATH
+
+if [ `tss2_list --searchPath=$KEY_PATH --pathList=-` != $SIGN_OBJECT ]; then
+  echo "tss2_list single object failed"
+  exit 1
+fi
+
+exit 0

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+NV_PATH=/nv/Owner/NvExtend
+DATA_EXTEND_FILE=$TEMP_DIR/nv_extend.data
+DATA_READ_FILE=$TEMP_DIR/nv_read.data
+LOG_DATA=$TEMP_DIR/log.data
+READ_LOG_DATA=$TEMP_DIR/read_log.data
+
+echo -n 01234567890123456789 > $DATA_EXTEND_FILE
+echo -n 01234567890123456789 > $LOG_DATA
+
+tss2_provision
+
+tss2_createnv --path $NV_PATH --type "noDa, pcr" --size 0
+
+tss2_nvextend --nvPath $NV_PATH --data $DATA_EXTEND_FILE --logData $LOG_DATA
+
+tss2_nvread --nvPath $NV_PATH --data $DATA_READ_FILE --logData $READ_LOG_DATA
+
+if [ ! -f $READ_LOG_DATA ]; then
+    echo "No log data returned"
+    exit 1
+fi
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_nvextend --data $DATA_EXTEND_FILE --logData $LOG_DATA
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing data
+spawn tss2_nvextend --nvPath $NV_PATH --logData $LOG_DATA
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-nv-increment.sh
+++ b/test/integration/fapi/fapi-nv-increment.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+NV_PATH=/nv/Owner/myNVcounter
+NV_COUNTER_READ_FILE=$TEMP_DIR/nv_counter_read_data.file
+PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+POLICY_PCR=policy/pcr-policy
+
+tss2_provision
+
+expect <<EOF
+# Try 2 different passwords
+spawn tss2_createnv --path $NV_PATH --type "counter, noDa" --size 0 --authValue
+expect "Password: "
+send "1\r"
+expect "Retype password: "
+send "2\r"
+expect {
+    "Passwords do not match" {
+            } eof {
+                send_user "Expected password mismatch, but got nothing, or
+                rather EOF\n"
+                exit 1
+            }
+        }
+        set ret [wait]
+        if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+            send_user "Using -P with different passwords on the prompt has not failed\n"
+            exit 1
+        }
+EOF
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+
+tss2_createnv --path $NV_PATH --policyPath=$POLICY_PCR --type "counter, noDa" \
+    --size 0
+
+tss2_nvincrement --nvPath $NV_PATH
+
+tss2_nvread --nvPath $NV_PATH --data $NV_COUNTER_READ_FILE --force
+
+tss2_nvincrement --nvPath $NV_PATH
+
+tss2_nvread --nvPath $NV_PATH --data $NV_COUNTER_READ_FILE --force
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_nvincrement
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-nv-set-bits.sh
+++ b/test/integration/fapi/fapi-nv-set-bits.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+NV_PATH="/nv/Owner/NvBitmap"
+BITMAP="0x0102030405060608"
+
+tss2_provision
+
+tss2_createnv --path $NV_PATH --type "noDa, bitfield" --size 0
+
+tss2_nvsetbits --nvPath $NV_PATH --bitmap $BITMAP
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_nvsetbits --bitmap $BITMAP
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing bitmap
+spawn tss2_nvsetbits --nvPath $NV_PATH
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong bitmap
+spawn tss2_nvsetbits --nvPath $NV_PATH --bitmap abc
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-nv-write-authorize.sh
+++ b/test/integration/fapi/fapi-nv-write-authorize.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+POLICY_SIGN_KEY_PATH="HS/SRK/policySignKey"
+SIGN_KEY_PATH="HS/SRK/signKey"
+NV_PATH="/nv/Owner/myNV"
+PCR_POLICY_JSON=$TEMP_DIR/pol_pcr16_0.json
+POLICY_PCR=policy/pcr-policy
+AUTHORIZE_NV_POLICY_JSON=$TEMP_DIR/pol_authorize_nv.json
+AUTHORIZE_NV_POLICY=policy/authorize-nv-policy
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
+DIGEST_FILE=$TEMP_DIR/digest.file
+echo -n 01234567890123456789 > $DIGEST_FILE
+
+tss2_provision
+
+tss2_createnv --path $NV_PATH --type "noDa" --size 34
+
+tss2_import --path $AUTHORIZE_NV_POLICY --importData $AUTHORIZE_NV_POLICY_JSON
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_JSON
+
+tss2_writeauthorizenv --nvPath $NV_PATH --policyPath $POLICY_PCR
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_writeauthorizenv --nvPath $NV_PATH --policyPath $POLICY_PCR
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
+    send_user "Command has failed. If using a physical TPM, see log since it is
+    probably not supported by TPM. Skipping test\n"
+    exit 77
+}
+EOF
+
+tss2_writeauthorizenv --nvPath $NV_PATH --policyPath $POLICY_PCR
+
+tss2_createkey --path $POLICY_SIGN_KEY_PATH --type "noDa, sign"
+
+tss2_createkey --path $SIGN_KEY_PATH --type "noDa, sign" \
+    --policyPath $AUTHORIZE_NV_POLICY
+
+tss2_sign --keyPath $SIGN_KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_writeauthorizenv --policyPath $POLICY_PCR
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing policyPath
+spawn tss2_writeauthorizenv --nvPath $NV_PATH
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try to fail command
+spawn tss2_writeauthorizenv --nvPath /abc/def --policyPath $POLICY_PCR
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+PW=abc
+NV_PATH=/nv/Owner/myNVwrite
+DATA_WRITE_FILE=$TEMP_DIR/nv_write_data.file
+DATA_READ_FILE=$TEMP_DIR/nv_read_data.file
+
+tss2_provision
+
+echo 1234567890123456789 > $DATA_WRITE_FILE
+
+tss2_createnv --path $NV_PATH --type "noDa" --size 20
+
+tss2_nvwrite --nvPath $NV_PATH --data $DATA_WRITE_FILE
+
+tss2_nvread --nvPath $NV_PATH --data $DATA_READ_FILE --force
+
+if [ `cat $DATA_READ_FILE` !=  `cat $DATA_WRITE_FILE` ]; then
+  echo "Test without password: Strings are not equal"
+  exit 99
+fi
+
+tss2_delete --path $NV_PATH
+
+tss2_createnv --path $NV_PATH --type "noDa" --size 20 --authValue=$PW
+
+expect <<EOF
+# Check if system asks for auth value and provide it
+spawn tss2_nvwrite --nvPath $NV_PATH --data $DATA_WRITE_FILE
+expect {
+    "Authorize object: " {
+    } eof {
+        send_user "The system has not asked for password\n"
+        exit 1
+    }
+    }
+    send "$PW\r"
+    set ret [wait]
+    if {[lindex \$ret 2] || [lindex \$ret 3]} {
+        send_user "Passing password has failed\n"
+        exit 1
+    }
+EOF
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_nvread --data $DATA_READ_FILE --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing data
+spawn tss2_nvread --nvPath $NV_PATH  --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing nvPath
+spawn tss2_nvwrite --data $DATA_WRITE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing data
+spawn tss2_nvwrite --data $DATA_WRITE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+NV_PATH=/nv/Owner/myNVwrite
+PCR_DIGEST_FILE=$TEMP_DIR/pcr_digest.file
+PCR_LOG_FILE_WRITE=$TEMP_DIR/pcr_log_write.file
+echo "abcdefghijklmnopqrstuvwxyz" > $PCR_LOG_FILE_WRITE
+PCR_LOG_FILE_READ=$TEMP_DIR/pcr_log_read.file
+PCR_EVENT_DATA=$TEMP_DIR/pcr_event_data.file
+echo "abcdefghijklmnopqrstuvwxyz" > $PCR_EVENT_DATA
+
+tss2_provision
+
+tss2_pcrextend --pcr 16 --data $PCR_EVENT_DATA \
+    --logData $PCR_LOG_FILE_WRITE
+
+tss2_pcrread --pcrIndex 16 --pcrValue $PCR_DIGEST_FILE \
+    --pcrLog $PCR_LOG_FILE_READ --force
+
+if [ ! -s $PCR_DIGEST_FILE ] || [ ! -s $PCR_LOG_FILE_READ ]; then
+    echo "At least one returned file is empty"
+    exit 1
+fi
+
+expect <<EOF
+# Try with missing pcr
+spawn tss2_pcrextend --data $PCR_EVENT_DATA --logData $PCR_LOG_FILE_WRITE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing data
+spawn tss2_pcrextend --pcr 16 --logData $PCR_LOG_FILE_WRITE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing logData
+spawn tss2_pcrextend --pcr 16 --data $PCR_EVENT_DATA
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong pcr
+spawn tss2_pcrextend --pcr abc --data $PCR_EVENT_DATA \
+    --logData $PCR_LOG_FILE_WRITE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing pcrIndex
+spawn tss2_pcrread --pcrValue $PCR_DIGEST_FILE --pcrLog $PCR_LOG_FILE_READ
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing pcrValue
+spawn tss2_pcrread --pcrIndex 16 --pcrLog $PCR_LOG_FILE_READ
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing pcrLog
+spawn tss2_pcrread --pcrIndex 16 --pcrValue $PCR_DIGEST_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with mutliple stdins
+spawn tss2_pcrread --pcrIndex 16 --pcrValue=- \
+    --pcrLog=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong pcrIndex
+spawn tss2_pcrread --pcrIndex abc --pcrValue $PCR_DIGEST_FILE \
+    --pcrLog $PCR_LOG_FILE_READ
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -17,10 +17,10 @@ trap cleanup EXIT
 NV_PATH=/nv/Owner/myNVwrite
 PCR_DIGEST_FILE=$TEMP_DIR/pcr_digest.file
 PCR_LOG_FILE_WRITE=$TEMP_DIR/pcr_log_write.file
-echo "abcdefghijklmnopqrstuvwxyz" > $PCR_LOG_FILE_WRITE
+echo "{\"test\": \"myfile\"}" > $PCR_LOG_FILE_WRITE
 PCR_LOG_FILE_READ=$TEMP_DIR/pcr_log_read.file
 PCR_EVENT_DATA=$TEMP_DIR/pcr_event_data.file
-echo "abcdefghijklmnopqrstuvwxyz" > $PCR_EVENT_DATA
+echo "0,1,2,3,4,5,6,7,8,9" > $PCR_EVENT_DATA
 
 tss2_provision
 

--- a/test/integration/fapi/fapi-provision.sh
+++ b/test/integration/fapi/fapi-provision.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    # Since clean up should already been done during normal run of the test, a
+    # failure is expected here. Therefore, we need to pass a successful
+    # execution in any case
+    tss2_delete --path / || true
+    shut_down
+}
+
+trap cleanup EXIT
+
+PW=abc
+
+tss2_provision --authValueSh $PW
+
+expect <<EOF
+# Change back to empty password
+spawn tss2_changeauth --entityPath=/HS
+expect "Authorize object: "
+send "$PW\r"
+expect "Authorize object: "
+send "$PW\r"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3]} {
+    send_user "Command failed\n"
+    exit 1
+}
+EOF
+
+PROFILE_NAME=$( tss2_list --searchPath= --pathList=- | cut -d "/" -f2 )
+
+tss2_delete --path /
+
+expect <<EOF
+# Test if still objects in path
+spawn tss2_list --path
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    send_user "Still objects in path\n"
+    exit 1
+}
+EOF
+
+if [ -s $PROFILE_NAME ];then
+    echo "Directory still existing"
+    exit 99
+fi
+
+exit 0

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/quotekey
+NONCE_FILE=$TEMP_DIR/nonce.file
+PUBLIC_QUOTE_KEY=$TEMP_DIR/public_quote.key
+QUOTE_INFO=$TEMP_DIR/quote.info
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+CERTIFICATE_FILE=$TEMP_DIR/certificate.file
+PCR_LOG=$TEMP_DIR/pcr.log
+
+printf "01234567890123456789" > $NONCE_FILE
+printf "01234567890123456789" > $PCR_LOG
+
+tss2_provision
+
+tss2_createkey --path $KEY_PATH --type "noDa, restricted, sign"
+
+tss2_quote --keyPath $KEY_PATH --pcrList "16" --qualifyingData $NONCE_FILE \
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
+    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO --force
+
+tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH --exportedData $PUBLIC_QUOTE_KEY --force
+tss2_import --path "ext/myNewParent" --importData $PUBLIC_QUOTE_KEY
+
+tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
+    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+
+expect <<EOF
+# Try with missing keyPath
+spawn tss2_quote --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing pcrList
+spawn tss2_quote \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing qualifyingData
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing signature
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE \
+    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing pcrLog
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing certificate
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing quoteInfo
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+    --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate=- \
+    --quoteInfo=- --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong pcrs
+spawn tss2_quote --keyPath $KEY_PATH --pcrList abc --qualifyingData $NONCE_FILE \
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
+    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Fail quote
+spawn tss2_quote --keyPath "/abc/def" --pcrList "16" --qualifyingData $NONCE_FILE \
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
+    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with already existing directory
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" --qualifyingData $NONCE_FILE \
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
+    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing publicKeyPath
+spawn tss2_verifyquote \
+    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
+    --signature $SIGNATURE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing qualifyingData
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --quoteInfo $QUOTE_INFO \
+    --signature $SIGNATURE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing quoteInfo
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE \
+    --signature $SIGNATURE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing signature
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo=- \
+    --signature=- --pcrLog=$PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong qualifyingData file
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData abc --quoteInfo $QUOTE_INFO \
+    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong signature file
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
+    --signature abc --pcrLog=$PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with wrong quoteInfo file
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo abc \
+    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try failing tss2_verifyquote
+spawn tss2_verifyquote --publicKeyPath "ext/abc" \
+    --qualifyingData $NONCE_FILE --quoteInfo abc \
+    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/sealKey
+SEALED_DATA=$TEMP_DIR/seal-data.file
+printf "data to seal" > $SEALED_DATA
+UNSEALED_DATA_FILE=$TEMP_DIR/unsealed-data.file
+PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
+POLICY_PCR=policy/pcr-policy
+
+tss2_provision
+
+expect <<EOF
+# Try 2 different passwords
+spawn tss2_createseal --path $KEY_PATH --type "noDa" --data $SEALED_DATA --authValue
+expect "Password: "
+send "1\r"
+expect "Retype password: "
+send "2\r"
+expect {
+    "Passwords do not match" {
+            } eof {
+                send_user "Expected password mismatch, but got nothing, or
+                rather EOF\n"
+                exit 1
+            }
+        }
+        set ret [wait]
+        if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+            send_user "Using -P with different passwords on the prompt has not failed\n"
+            exit 1
+        }
+EOF
+
+expect <<EOF
+# Try with missing path
+spawn tss2_createseal --type "noDa" --data $SEALED_DATA
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing type
+spawn tss2_createseal --path $KEY_PATH --data $SEALED_DATA
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+
+tss2_createseal --path $KEY_PATH --policyPath=$POLICY_PCR --type "noDa" \
+    --data $SEALED_DATA
+tss2_unseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --force
+
+if [ "`cat $UNSEALED_DATA_FILE`" != "`cat $SEALED_DATA`" ]; then
+  echo "Seal/Unseal failed"
+  exit 1
+fi
+
+expect <<EOF
+# Try with missing path
+spawn tss2_unseal --data $UNSEALED_DATA_FILE --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing data
+spawn tss2_unseal --path $KEY_PATH --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/myRSACrypt
+APP_DATA_SET=$TEMP_DIR/sample_app_data
+APP_DATA_FILE=$TEMP_DIR/app_data.file
+
+echo -n "abcdef" > $APP_DATA_SET
+
+tss2_provision
+
+tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt"
+
+tss2_setappdata --path $KEY_PATH --appData $APP_DATA_SET
+
+tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
+
+if [ `cat $APP_DATA_FILE` !=  "$APP_DATA_SET" ]; then
+  echo "Strings are not equal"
+  exit 99
+fi
+
+expect <<EOF
+# Try with missing path
+spawn tss2_getappdata --appData $APP_DATA_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/myRSACrypt
+# cat > $tempdir/fapi_config.json <<EOF
+
+READ_CERTIFICATE_FILE=$TEMP_DIR/read_certificate.file
+WRITE_CERTIFICATE_FILE=$TEMP_DIR/write_certificate.file
+
+cat > $WRITE_CERTIFICATE_FILE <<EOF
+    "-----BEGIN CERTIFICATE-----\n\
+    MIIDBjCCAe4CCQDcvXBOEVM0UTANBgkqhkiG9w0BAQsFADBFMQswCQYDVQQGEwJE\n\
+    RTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0\n\
+    cyBQdHkgTHRkMB4XDTE5MDIyODEwNDkyM1oXDTM1MDgyNzEwNDkyM1owRTELMAkG\n\
+    A1UEBhMCREUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0\n\
+    IFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\n\
+    AKBi+iKwkgM55iCMwXrLCJlu7TzlMu/LlkyGrm99ip2B5+/Cl6a62d8pKelg6zkH\n\
+    jI7+AAPteJiW4O+2qVWF8hJ5BXTjGtYbM0iZ6enCb8eyC54C7xVMc21ZIv3ob4Et\n\
+    50ZOuzY2pfpzE3vIaXt1CkHlfyI/hdK+mM/dVvuCz5p3AIlHrEWS3rSNgWbCsB2E\n\
+    TM55qSGKaLmtTbUvEKRF0TJrFLntfXkv10QD5pgn52+QV9k59OogqZOsDvkXzKPX\n\
+    rXF+XC0gLiGBEGAr1dv9F03xMOtO77bQTdGOeC61Tip6Nb0V3ebMckZXwdFi+Nhe\n\
+    FRuU33CaObtV6u5PZvSue/MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAcamUPe8I\n\
+    nMOHcv9x5lVN1joihVRmKc0QqNLFc6XpJY8+U5rGkZvOcDe9Da8L97wDNXpKmU/q\n\
+    pprj3rT8l3v0Z5xs8Vdr8lxS6T5NhqQV0UCsn1x14gZJcE48y9/LazYi6Zcar+BX\n\
+    Am4vewAV3HmQ8X2EctsRhXe4wlAq4slIfEWaaofa8ai7BzO9KwpMLsGPWoNetkB9\n\
+    19+SFt0lFFOj/6vDw5pCpSd1nQlo1ug69mJYSX/wcGkV4t4LfGhV8jRPDsGs6I5n\n\
+    ETHSN5KV1XCPYJmRCjFY7sIt1x4zN7JJRO9DVw+YheIlduVfkBiF+GlQgLlFTjrJ\n\
+    VrpSGMIFSu301A==\n\
+    -----END CERTIFICATE-----\n"
+EOF
+
+tss2_provision
+
+tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt"
+
+tss2_setcertificate --path $KEY_PATH --x509certData $WRITE_CERTIFICATE_FILE
+
+tss2_getcertificate --path $KEY_PATH --x509certData $READ_CERTIFICATE_FILE \
+    --force
+
+if [ ! cmp -s "$WRITE_CERTIFICATE_FILE" "$READ_CERTIFICATE_FILE" ]; then
+  echo "Certificates not equal"
+  exit 1
+fi
+
+expect <<EOF
+# Try with missing path
+spawn tss2_setcertificate \
+    --x509certData $WRITE_CERTIFICATE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing cert
+spawn tss2_setcertificate --path $KEY_PATH
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing path
+spawn tss2_getcertificate --x509certData $READ_CERTIFICATE_FILE --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing x509certData
+spawn tss2_getcertificate --path $KEY_PATH --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/myRSACrypt
+DESCRIPTION_SET=$TEMP_DIR/object-description
+DESCRIPTION_FILE=$TEMP_DIR/object_description.file
+
+echo -n "description data" > DESCRIPTION_SET
+
+tss2_provision
+
+tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt"
+
+tss2_setdescription --path $KEY_PATH --description $DESCRIPTION_SET
+
+tss2_getdescription --path $KEY_PATH --description $DESCRIPTION_FILE --force
+
+if [ `cat $DESCRIPTION_FILE` !=  "$DESCRIPTION_SET" ]; then
+  echo "Descriptions not equal"
+  exit 1
+fi
+
+expect <<EOF
+# Try with missing path
+spawn tss2_setdescription --description $DESCRIPTION_SET
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing description
+spawn tss2_setdescription --path $KEY_PATH
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing path
+spawn tss2_getdescription --description $DESCRIPTION_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing description
+spawn tss2_getdescription --path $KEY_PATH
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    tss2_delete --path /
+    shut_down
+}
+
+trap cleanup EXIT
+
+KEY_PATH=HS/SRK/myRSASign
+DIGEST_FILE=$TEMP_DIR/digest.file
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
+IMPORTED_KEY_NAME="importedPubKey"
+PUB_KEY_DIR="ext"
+
+tss2_provision
+echo -n "01234567890123456789" > $DIGEST_FILE
+tss2_createkey --path $KEY_PATH --type "noDa, sign"
+echo -n `cat $DIGEST_FILE` | tss2_sign --digest=- --keyPath $KEY_PATH \
+    --padding "RSA_PSS" --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+
+tss2_import --path $IMPORTED_KEY_NAME --importData $PUBLIC_KEY_FILE
+tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --digest $DIGEST_FILE --signature $SIGNATURE_FILE
+
+
+expect <<EOF
+# Try with missing keyPath
+spawn tss2_sign --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing digest
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing signature
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --publicKey $PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins with publicKey and without certificate
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature=- --publicKey=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins with publicKey and with certificate
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature=- --publicKey=- --certificate=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins without publicKey and with certificate
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature=- --certificate=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing digest file
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest abc \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing signature file
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature abc --publicKey $PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing public key file
+spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey abc
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing keyPath
+spawn tss2_verifysignature \
+    --digest $DIGEST_FILE --signature $SIGNATURE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing digest
+spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --signature $SIGNATURE_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with missing signature
+spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --digest $DIGEST_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins
+spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --digest=- --signature=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/fapi/fapi-testing-template.sh
+++ b/test/integration/fapi/fapi-testing-template.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+source helpers.sh
+
+start_up
+
+setup_fapi
+
+function cleanup {
+    # If this test is successful, no keys are created. Thus, command below will
+    # always fail
+    tss2_delete --path / || true
+    shut_down
+}
+
+trap cleanup EXIT
+
+PW=abc
+PLAIN_TEXT=$TEMP_DIR/plaintext.file
+KEY_PATH="HS/SRK/myRSACrypt"
+ENCRYPTED_FILE=$TEMP_DIR/encrypted.file
+echo -n "Secret Text!" > $PLAIN_TEXT
+
+expect <<EOF
+# Try with wrong help argument
+spawn tss2_provision -h abc
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+tss2_provision -h man
+
+tss2_provision -h no-man
+
+tss2_provision -v
+
+expect <<EOF
+# Try with wrong option
+spawn tss2_provision -abcdef
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+exit 0

--- a/test/integration/tests/abrmd_policyor.sh
+++ b/test/integration/tests/abrmd_policyor.sh
@@ -13,7 +13,9 @@ concatenated=con.cat
 
 cleanup() {
     rm -f $policy_1 $policy_2 $policy_init $test_vector $policyor_cc \
-    $session_ctx $policy_digest $concatenated
+    $session_ctx $policy_digest $concatenated \
+    set1.pcr0.policy set2.pcr0.policy prim.ctx sealkey.priv sealkey.pub \
+    sealkey.ctx policyOR
 
     tpm2_flushcontext $session_ctx 2>/dev/null || true
 
@@ -39,5 +41,54 @@ tpm2_policyor -L $o_policy_digest -S $session_ctx sha256:$policy_1,$policy_2
 tpm2_flushcontext $session_ctx
 
 diff $test_vector $o_policy_digest
+
+# Test case to compound two PCR policies
+
+tpm2_pcrreset 23
+tpm2_startauthsession -S session.ctx
+tpm2_policypcr -S session.ctx -l sha1:23 -L set1.pcr0.policy
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+tpm2_startauthsession -S session.ctx
+tpm2_policypcr -S session.ctx -l sha1:23 -L set2.pcr0.policy
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_startauthsession -S session.ctx
+tpm2_policyor -S session.ctx -L policyOR \
+sha256:set1.pcr0.policy,set2.pcr0.policy
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_createprimary -C o -c prim.ctx
+tpm2_create -g sha256 -u sealkey.pub -r sealkey.priv -L policyOR -C prim.ctx \
+-i- <<< "secretpass"
+tpm2_load -C prim.ctx -c sealkey.ctx -u sealkey.pub -r sealkey.priv
+
+tpm2_startauthsession -S session.ctx --policy-session
+tpm2_policypcr -S session.ctx -l sha1:23
+tpm2_policyor -S session.ctx -L policyOR \
+sha256:set1.pcr0.policy,set2.pcr0.policy
+unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
+echo $unsealed
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+tpm2_startauthsession -S session.ctx --policy-session
+tpm2_policypcr -S session.ctx -l sha1:23
+
+tpm2_pcrreset 23
+
+tpm2_startauthsession -S session.ctx --policy-session
+tpm2_policypcr -S session.ctx -l sha1:23
+tpm2_policyor -S session.ctx -L policyOR \
+sha256:set1.pcr0.policy,set2.pcr0.policy
+unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
+echo $unsealed
+tpm2_flushcontext session.ctx
+rm session.ctx
 
 exit 0

--- a/test/integration/tests/abrmd_policyor.sh
+++ b/test/integration/tests/abrmd_policyor.sh
@@ -35,7 +35,7 @@ cat $policy_init $policyor_cc $policy_1 $policy_2 > $concatenated
 openssl dgst -binary -sha256 $concatenated > $test_vector
 
 tpm2_startauthsession -S $session_ctx
-tpm2_policyor -L $o_policy_digest -l sha256:$policy_1,$policy_2 -S $session_ctx
+tpm2_policyor -L $o_policy_digest -S $session_ctx sha256:$policy_1,$policy_2
 tpm2_flushcontext $session_ctx
 
 diff $test_vector $o_policy_digest

--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -38,12 +38,10 @@ else
     fi
 fi
 
-tpm2_getekcertificate -u test_ek.pub -x -X -o ECcert.bin \
-https://ekop.intel.com/ekcertservice/
+tpm2_getekcertificate -u test_ek.pub -x -X -o ECcert.bin
 
 # Test that stdoutput is the same
-tpm2_getekcertificate -u test_ek.pub -x https://ekop.intel.com/ekcertservice/ \
--X > ECcert2.bin
+tpm2_getekcertificate -u test_ek.pub -x -X > ECcert2.bin
 
 # stdout file should match -E file.
 cmp ECcert.bin ECcert2.bin

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -60,7 +60,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     TSS2_RC r;
     uint8_t *policyRef = NULL;
     size_t policyRefSize = 0;
-    if(ctx.policyRef){
+    if (ctx.policyRef){
         r = open_read_and_close (ctx.policyRef, (void**)&policyRef,
             &policyRefSize);
         if (r){

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char  const *policyPath;
+    char  const *keyPath; /* the path to the signing key */
+    char  const *policyRef;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.policyPath = value;
+        break;
+    case 'k':
+        ctx.keyPath = value;
+        break;
+    case 'r':
+        ctx.policyRef = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"policyPath", required_argument, NULL, 'p'},
+        {"keyPath",    required_argument, NULL, 'k'},
+        {"policyRef",    required_argument, NULL, 'r'},
+    };
+    return (*opts = tpm2_options_new ("p:k:r.", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.policyPath) {
+        fprintf (stderr, "policy path to sign is missing, pass" \
+            "--policyPath=\n");
+        return -1;
+    }
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path for signing key is missing, pass" \
+            "--keyPath=\n");
+        return -1;
+    }
+
+    /* Read ciphertext file */
+    TSS2_RC r;
+    uint8_t *policyRef = NULL;
+    size_t policyRefSize = 0;
+    if(ctx.policyRef){
+        r = open_read_and_close (ctx.policyRef, (void**)&policyRef,
+            &policyRefSize);
+        if (r){
+            LOG_PERR ("open_read_and_close policyRef", r);
+            return r;
+        }
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_AuthorizePolicy (fctx, ctx.policyPath, ctx.keyPath, policyRef,
+        policyRefSize);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_AuthorizePolicy", r);
+        return r;
+    }
+
+    free(policyRef);
+
+    return r;
+}

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'p':
+    case 'P':
         ctx.policyPath = value;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
     case 'r':
@@ -34,11 +34,11 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"policyPath", required_argument, NULL, 'p'},
-        {"keyPath",    required_argument, NULL, 'k'},
+        {"policyPath", required_argument, NULL, 'P'},
+        {"keyPath",    required_argument, NULL, 'p'},
         {"policyRef",    required_argument, NULL, 'r'},
     };
-    return (*opts = tpm2_options_new ("p:k:r.", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("P:p:r.", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,12 +47,12 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.policyPath) {
         fprintf (stderr, "policy path to sign is missing, pass" \
-            "--policyPath=\n");
+            "--policyPath\n");
         return -1;
     }
     if (!ctx.keyPath) {
         fprintf (stderr, "key path for signing key is missing, pass" \
-            "--keyPath=\n");
+            "--keyPath\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char  const *policyPath;
+    char  const *keyPath; /* the path to the signing key */
+    char  const *policyRef;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'r':
+        ctx.policyRef = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"policyPath", required_argument, NULL, 'P'},
+        {"keyPath",    required_argument, NULL, 'p'},
+        {"policyRef",    required_argument, NULL, 'r'},
+    };
+    return (*opts = tpm2_options_new ("P:p:r.", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.policyPath) {
+        fprintf (stderr, "policy path to sign is missing, pass" \
+            "--policyPath\n");
+        return -1;
+    }
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path for signing key is missing, pass" \
+            "--keyPath\n");
+        return -1;
+    }
+
+    /* Read ciphertext file */
+    TSS2_RC r;
+    uint8_t *policyRef = NULL;
+    size_t policyRefSize = 0;
+    if (ctx.policyRef){
+        r = open_read_and_close (ctx.policyRef, (void**)&policyRef,
+            &policyRefSize);
+        if (r){
+            LOG_PERR ("open_read_and_close policyRef", r);
+            return r;
+        }
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_AuthorizePolicy (fctx, ctx.policyPath, ctx.keyPath, policyRef,
+        policyRefSize);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_AuthorizePolicy", r);
+        return r;
+    }
+
+    free(policyRef);
+
+    return r;
+}

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char *entityPath;
+    char *authValue;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'p':
+        ctx.entityPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"authValue", optional_argument, NULL, 'a'},
+        {"entityPath", required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("a:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.entityPath) {
+        fprintf (stderr, "No entity path provided, use --entityPath\n");
+        if (ctx.authValue){
+            free (ctx.authValue);
+        }
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_ChangeAuth(fctx, ctx.entityPath, ctx.authValue);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_ChangeAuth", r);
+        return 1;
+    }
+
+    if (ctx.authValue){
+        free (ctx.authValue);
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -45,7 +45,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.entityPath) {
         fprintf (stderr, "No entity path provided, use --entityPath=\n");
-        if(ctx.authValue){
+        if (ctx.authValue){
             free (ctx.authValue);
         }
         return -1;
@@ -58,7 +58,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
 
-    if(ctx.authValue){
+    if (ctx.authValue){
         free (ctx.authValue);
     }
 

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -23,7 +23,7 @@ static bool on_option(char key, char *value) {
         if (!ctx.authValue)
             return false; /* User entered two different passwords */
         break;
-    case 'e':
+    case 'p':
         ctx.entityPath = value;
         break;
     }
@@ -34,9 +34,9 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"authValue", optional_argument, NULL, 'a'},
-        {"entityPath", required_argument, NULL, 'e'}
+        {"entityPath", required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("a:e:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("a:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -44,7 +44,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.entityPath) {
-        fprintf (stderr, "No entity path provided, use --entityPath=\n");
+        fprintf (stderr, "No entity path provided, use --entityPath\n");
         if (ctx.authValue){
             free (ctx.authValue);
         }

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char *entityPath;
+    char *authValue;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'e':
+        ctx.entityPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"authValue", optional_argument, NULL, 'a'},
+        {"entityPath", required_argument, NULL, 'e'}
+    };
+    return (*opts = tpm2_options_new ("a:e:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.entityPath) {
+        fprintf (stderr, "No entity path provided, use --entityPath=\n");
+        if(ctx.authValue){
+            free (ctx.authValue);
+        }
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_ChangeAuth(fctx, ctx.entityPath, ctx.authValue);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_ChangeAuth", r);
+        return 1;
+    }
+
+    if(ctx.authValue){
+        free (ctx.authValue);
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *keyType;
+    char const *policyPath;
+    char       *authValue;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'l':
+        ctx.policyPath = value;
+        break;
+    case 't':
+        ctx.keyType = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path"       , required_argument, NULL, 'p'},
+        {"type"       , required_argument, NULL, 't'},
+        {"policyPath", required_argument, NULL, 'l'},
+        {"authValue"   , optional_argument, NULL, 'a'},
+    };
+    return (*opts = tpm2_options_new ("a:p:l:t:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path missing, use --path=\n");
+        free (ctx.authValue);
+        return -1;
+    }
+    if (!ctx.keyType) {
+        fprintf (stderr, "key type missing, use --type=\n");
+        free (ctx.authValue);
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_CreateKey (fctx, ctx.keyPath, ctx.keyType, ctx.policyPath,
+        ctx.authValue);
+    if (r != TSS2_RC_SUCCESS){
+        free (ctx.authValue);
+        LOG_PERR ("Fapi_CreateKey", r);
+        return r;
+    }
+
+    free (ctx.authValue);
+    return r;
+}

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -28,7 +28,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.keyPath = value;
         break;
-    case 'l':
+    case 'P':
         ctx.policyPath = value;
         break;
     case 't':
@@ -43,10 +43,10 @@ bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"       , required_argument, NULL, 'p'},
         {"type"       , required_argument, NULL, 't'},
-        {"policyPath", required_argument, NULL, 'l'},
+        {"policyPath", required_argument, NULL, 'P'},
         {"authValue"   , optional_argument, NULL, 'a'},
     };
-    return (*opts = tpm2_options_new ("a:p:l:t:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("a:p:P:t:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -54,12 +54,12 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "key path missing, use --path=\n");
+        fprintf (stderr, "key path missing, use --path\n");
         free (ctx.authValue);
         return -1;
     }
     if (!ctx.keyType) {
-        fprintf (stderr, "key type missing, use --type=\n");
+        fprintf (stderr, "key type missing, use --type\n");
         free (ctx.authValue);
         return -1;
     }

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *keyType;
+    char const *policyPath;
+    char       *authValue;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 't':
+        ctx.keyType = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path"       , required_argument, NULL, 'p'},
+        {"type"       , required_argument, NULL, 't'},
+        {"policyPath", required_argument, NULL, 'P'},
+        {"authValue"   , optional_argument, NULL, 'a'},
+    };
+    return (*opts = tpm2_options_new ("a:p:P:t:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path missing, use --path\n");
+        free (ctx.authValue);
+        return -1;
+    }
+    if (!ctx.keyType) {
+        fprintf (stderr, "key type missing, use --type\n");
+        free (ctx.authValue);
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_CreateKey (fctx, ctx.keyPath, ctx.keyType, ctx.policyPath,
+        ctx.authValue);
+    if (r != TSS2_RC_SUCCESS){
+        free (ctx.authValue);
+        LOG_PERR ("Fapi_CreateKey", r);
+        return r;
+    }
+
+    free (ctx.authValue);
+    return r;
+}

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char     const *nvPath;
+    char     const *nvTemplate;
+    char           *authValue;
+    uint32_t        size;
+    char     const *policyPath;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 'p':
+        ctx.nvPath = value;
+        break;
+    case 's':
+        if (!tpm2_util_string_to_uint32 (value, &ctx.size)) {
+            fprintf (stderr, "%s cannot be converted to an integer or is" \
+                " larger than 2**32 - 1\n", value);
+            return false;
+        }
+        break;
+    case 't':
+        ctx.nvTemplate = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path",        required_argument, NULL, 'p'},
+        {"type",        required_argument, NULL, 't'},
+        {"size"       , required_argument, NULL, 's'},
+        {"policyPath", optional_argument, NULL, 'P'},
+        {"authValue",    optional_argument, NULL, 'a'},
+    };
+    return (*opts = tpm2_options_new ("P:a:p:s:t:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if(!ctx.authValue){
+        ctx.authValue = "";
+    }
+    if (!ctx.policyPath) {
+        ctx.policyPath = "";
+    }
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --path=\n");
+        return -1;
+    }
+
+    if (!ctx.nvTemplate) {
+        fprintf (stderr, "No type provided, use --type=[file or" \
+            " '-' for standard input]\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_CreateNv(fctx, ctx.nvPath, ctx.nvTemplate,
+        ctx.size, ctx.policyPath, ctx.authValue);
+
+    if (r != TSS2_RC_SUCCESS)
+        LOG_PERR ("Fapi_CreateNv", r);
+    return r;
+}

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -63,7 +63,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
-    if(!ctx.authValue){
+    if (!ctx.authValue){
         ctx.authValue = "";
     }
     if (!ctx.policyPath) {

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -70,13 +70,12 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         ctx.policyPath = "";
     }
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --path=\n");
+        fprintf (stderr, "No NV path provided, use --path\n");
         return -1;
     }
 
     if (!ctx.nvTemplate) {
-        fprintf (stderr, "No type provided, use --type=[file or" \
-            " '-' for standard input]\n");
+        fprintf (stderr, "No type provided, use --type\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char     const *nvPath;
+    char     const *nvTemplate;
+    char           *authValue;
+    uint32_t        size;
+    char     const *policyPath;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 'p':
+        ctx.nvPath = value;
+        break;
+    case 's':
+        if (!tpm2_util_string_to_uint32 (value, &ctx.size)) {
+            fprintf (stderr, "%s cannot be converted to an integer or is" \
+                " larger than 2**32 - 1\n", value);
+            return false;
+        }
+        break;
+    case 't':
+        ctx.nvTemplate = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path",        required_argument, NULL, 'p'},
+        {"type",        required_argument, NULL, 't'},
+        {"size"       , required_argument, NULL, 's'},
+        {"policyPath", optional_argument, NULL, 'P'},
+        {"authValue",    optional_argument, NULL, 'a'},
+    };
+    return (*opts = tpm2_options_new ("P:a:p:s:t:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.authValue){
+        ctx.authValue = "";
+    }
+    if (!ctx.policyPath) {
+        ctx.policyPath = "";
+    }
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --path\n");
+        return -1;
+    }
+
+    if (!ctx.nvTemplate) {
+        fprintf (stderr, "No type provided, use --type\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_CreateNv(fctx, ctx.nvPath, ctx.nvTemplate,
+        ctx.size, ctx.policyPath, ctx.authValue);
+
+    if (r != TSS2_RC_SUCCESS)
+        LOG_PERR ("Fapi_CreateNv", r);
+    return r;
+}

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *keyType;
+    char const *policyPath;
+    char       *authValue;
+    char const *data;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 't':
+        ctx.keyType = value;
+        break;
+    case 'd':
+        ctx.data = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path",        required_argument, NULL, 'p'},
+        {"type",        required_argument, NULL, 't'},
+        {"policyPath",  required_argument, NULL, 'P'},
+        {"authValue",    optional_argument, NULL, 'a'},
+        {"data"       , required_argument, NULL, 'd'}
+    };
+    return (*opts = tpm2_options_new ("a:p:P:t:d:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path missing, use --path=\n");
+        free (ctx.authValue);
+        return -1;
+    }
+    if (!ctx.keyType) {
+        fprintf (stderr, "key type missing, use --type=\n");
+        free (ctx.authValue);
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "data to seal missing, use --data=\n");
+        free (ctx.authValue);
+        return -1;
+    }
+
+    /* Read data file */
+    uint8_t* data;
+    size_t dataSize;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &dataSize);
+    if (r){
+        LOG_PERR ("open_read_and_close data", r);
+        return r;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_CreateSeal (fctx, ctx.keyPath, ctx.keyType,
+        dataSize, ctx.policyPath, ctx.authValue, data);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_CreateSeal", r);
+        return 1;
+    }
+    Fapi_Free(data);
+    free (ctx.authValue);
+    return 0;
+}

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *keyType;
+    char const *policyPath;
+    char       *authValue;
+    char const *data;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.authValue = value ? strdup (value) : ask_for_password ();
+        if (!ctx.authValue)
+            return false; /* User entered two different passwords */
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 't':
+        ctx.keyType = value;
+        break;
+    case 'i':
+        ctx.data = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path",        required_argument, NULL, 'p'},
+        {"type",        required_argument, NULL, 't'},
+        {"policyPath",  required_argument, NULL, 'P'},
+        {"authValue",    optional_argument, NULL, 'a'},
+        {"data"       , required_argument, NULL, 'i'}
+    };
+    return (*opts = tpm2_options_new ("a:p:P:t:i:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path missing, use --path\n");
+        free (ctx.authValue);
+        return -1;
+    }
+    if (!ctx.keyType) {
+        fprintf (stderr, "key type missing, use --type\n");
+        free (ctx.authValue);
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "data to seal missing, use --data\n");
+        free (ctx.authValue);
+        return -1;
+    }
+
+    /* Read data file */
+    uint8_t* data;
+    size_t dataSize;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &dataSize);
+    if (r){
+        LOG_PERR ("open_read_and_close data", r);
+        return r;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_CreateSeal (fctx, ctx.keyPath, ctx.keyType,
+        dataSize, ctx.policyPath, ctx.authValue, data);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_CreateSeal", r);
+        return 1;
+    }
+    Fapi_Free(data);
+    free (ctx.authValue);
+    return 0;
+}

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -35,7 +35,7 @@ static bool on_option(char key, char *value) {
     case 't':
         ctx.keyType = value;
         break;
-    case 'd':
+    case 'i':
         ctx.data = value;
         break;
     }
@@ -49,9 +49,9 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"type",        required_argument, NULL, 't'},
         {"policyPath",  required_argument, NULL, 'P'},
         {"authValue",    optional_argument, NULL, 'a'},
-        {"data"       , required_argument, NULL, 'd'}
+        {"data"       , required_argument, NULL, 'i'}
     };
-    return (*opts = tpm2_options_new ("a:p:P:t:d:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("a:p:P:t:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -59,17 +59,17 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "key path missing, use --path=\n");
+        fprintf (stderr, "key path missing, use --path\n");
         free (ctx.authValue);
         return -1;
     }
     if (!ctx.keyType) {
-        fprintf (stderr, "key type missing, use --type=\n");
+        fprintf (stderr, "key type missing, use --type\n");
         free (ctx.authValue);
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "data to seal missing, use --data=\n");
+        fprintf (stderr, "data to seal missing, use --data\n");
         free (ctx.authValue);
         return -1;
     }

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -19,16 +19,16 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'c':
+    case 'i':
         ctx.cipherText = value;
         break;
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'p':
+    case 'o':
         ctx.plainText = value;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
     }
@@ -38,12 +38,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
-        {"cipherText", required_argument, NULL, 'c'},
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"cipherText", required_argument, NULL, 'i'},
         {"force"      , no_argument      , NULL, 'f'},
-        {"plainText"     , required_argument, NULL, 'p'},
+        {"plainText"     , required_argument, NULL, 'o'},
     };
-    return (*opts = tpm2_options_new ("c:f:p:k:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:f:o:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -51,17 +51,15 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "No key path provided, use --keyPath=\n");
+        fprintf (stderr, "No key path provided, use --keyPath\n");
         return -1;
     }
     if (!ctx.cipherText) {
-        fprintf (stderr, "No encrypted text provided, use --cipherText=[file" \
-            " or '-' for standard input]\n");
+        fprintf (stderr, "No encrypted text provided, use --cipherText\n");
         return -1;
     }
     if (!ctx.plainText) {
-        fprintf (stderr, "No output file provided, use --plainText=[file or '-'" \
-            " for standard output]\n");
+        fprintf (stderr, "No output file provided, use --plainText\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *plainText;
+    char const *cipherText;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'c':
+        ctx.cipherText = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.plainText = value;
+        break;
+    case 'k':
+        ctx.keyPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'k'},
+        {"cipherText", required_argument, NULL, 'c'},
+        {"force"      , no_argument      , NULL, 'f'},
+        {"plainText"     , required_argument, NULL, 'p'},
+    };
+    return (*opts = tpm2_options_new ("c:f:p:k:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "No key path provided, use --keyPath=\n");
+        return -1;
+    }
+    if (!ctx.cipherText) {
+        fprintf (stderr, "No encrypted text provided, use --cipherText=[file" \
+            " or '-' for standard input]\n");
+        return -1;
+    }
+    if (!ctx.plainText) {
+        fprintf (stderr, "No output file provided, use --plainText=[file or '-'" \
+            " for standard output]\n");
+        return -1;
+    }
+
+    /* Read ciphertext file */
+    uint8_t* cipherText;
+    size_t cipherTextSize;
+    TSS2_RC r = open_read_and_close (ctx.cipherText, (void**)&cipherText,
+        &cipherTextSize);
+    if (r){
+        LOG_PERR ("open_read_and_close cipherText", r);
+        return r;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *plainText;
+    size_t plainTextSize;
+    r = Fapi_Decrypt (fctx, ctx.keyPath, cipherText, cipherTextSize,
+        &plainText, &plainTextSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Decrypt", r);
+        return 1;
+    }
+    free(cipherText);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.plainText, ctx.overwrite, plainText,
+        plainTextSize);
+    if (r){
+        LOG_PERR ("open_write_and_close plainText", r);
+        return r;
+    }
+
+    Fapi_Free (plainText);
+    return r;
+}

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *plainText;
+    char const *cipherText;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i':
+        ctx.cipherText = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'o':
+        ctx.plainText = value;
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"cipherText", required_argument, NULL, 'i'},
+        {"force"      , no_argument      , NULL, 'f'},
+        {"plainText"     , required_argument, NULL, 'o'},
+    };
+    return (*opts = tpm2_options_new ("i:f:o:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "No key path provided, use --keyPath\n");
+        return -1;
+    }
+    if (!ctx.cipherText) {
+        fprintf (stderr, "No encrypted text provided, use --cipherText\n");
+        return -1;
+    }
+    if (!ctx.plainText) {
+        fprintf (stderr, "No output file provided, use --plainText\n");
+        return -1;
+    }
+
+    /* Read ciphertext file */
+    uint8_t* cipherText;
+    size_t cipherTextSize;
+    TSS2_RC r = open_read_and_close (ctx.cipherText, (void**)&cipherText,
+        &cipherTextSize);
+    if (r){
+        LOG_PERR ("open_read_and_close cipherText", r);
+        return r;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *plainText;
+    size_t plainTextSize;
+    r = Fapi_Decrypt (fctx, ctx.keyPath, cipherText, cipherTextSize,
+        &plainText, &plainTextSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Decrypt", r);
+        return 1;
+    }
+    free(cipherText);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.plainText, ctx.overwrite, plainText,
+        plainTextSize);
+    if (r){
+        LOG_PERR ("open_write_and_close plainText", r);
+        return r;
+    }
+
+    Fapi_Free (plainText);
+    return r;
+}

--- a/tools/fapi/tss2_delete.c
+++ b/tools/fapi/tss2_delete.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+static char *path;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path", required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    if (!path) {
+        fprintf (stderr, "No path to the entity provided, use --path\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_Delete(fctx, path);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_Delete", r);
+    }
+    return r != 0;
+}

--- a/tools/fapi/tss2_delete.c
+++ b/tools/fapi/tss2_delete.c
@@ -31,7 +31,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (!path) {
-        fprintf (stderr, "No path to the entity provided, use --path=\n");
+        fprintf (stderr, "No path to the entity provided, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_delete.c
+++ b/tools/fapi/tss2_delete.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+static char *path;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path", required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    if (!path) {
+        fprintf (stderr, "No path to the entity provided, use --path=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_Delete(fctx, path);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_Delete", r);
+    }
+    return r != 0;
+}

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *policyPath;
+    char const *plainText;
+    char const *cipherText;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    case 'o':
+        ctx.cipherText = value;
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'i':
+        ctx.plainText = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"policyPath",  required_argument, NULL, 'P'},
+        {"plainText",   required_argument, NULL, 'i'},
+        {"cipherText",  required_argument, NULL, 'o'},
+        {"force",       no_argument      , NULL, 'f'},
+    };
+    return (*opts = tpm2_options_new ("f:P:o:p:i:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "No key path provided, use --keyPath\n");
+        return -1;
+    }
+    if (!ctx.plainText) {
+        fprintf (stderr, "No text to encrypt provided, use --plainText\n");
+        return -1;
+    }
+    if (!ctx.cipherText) {
+        fprintf (stderr, "No output file provided, --cipherText\n");
+        return -1;
+    }
+
+    /* Read plaintext file */
+    uint8_t *plainText;
+    size_t plainTextSize;
+    TSS2_RC r = open_read_and_close (ctx.plainText, (void**)&plainText,
+        &plainTextSize);
+    if (r){
+        LOG_PERR ("open_read_and_close plainText", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *cipherText;
+    size_t cipherTextSize;
+    r = Fapi_Encrypt (fctx, ctx.keyPath, plainText, plainTextSize,
+        &cipherText, &cipherTextSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Encrypt", r);
+        free (plainText);
+        return 1;
+    }
+    free (plainText);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.cipherText, ctx.overwrite, cipherText,
+        cipherTextSize);
+    if (r) {
+        LOG_PERR ("open_write_and_close cipherText", r);
+        return 1;
+    }
+
+    Fapi_Free (cipherText);
+    return 0;
+}

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *policyPath;
+    char const *plainText;
+    char const *cipherText;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.policyPath = value;
+        break;
+    case 'c':
+        ctx.cipherText = value;
+        break;
+    case 'k':
+        ctx.keyPath = value;
+        break;
+    case 'P':
+        ctx.plainText = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'k'},
+        {"policyPath",  required_argument, NULL, 'p'},
+        {"plainText",   required_argument, NULL, 'P'},
+        {"cipherText",  required_argument, NULL, 'c'},
+        {"force",       no_argument      , NULL, 'f'},
+    };
+    return (*opts = tpm2_options_new ("f:p:c:k:P:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "No key path provided, use --keyPath=\n");
+        return -1;
+    }
+    if (!ctx.plainText) {
+        fprintf (stderr, "No text to encrypt provided, use --plainText=[file" \
+            ", or '-' for standard input]\n");
+        return -1;
+    }
+    if (!ctx.cipherText) {
+        fprintf (stderr, "No output file provided, --cipherText=[file, or " \
+            "'-' for standard output]\n");
+        return -1;
+    }
+
+    /* Read plaintext file */
+    uint8_t *plainText;
+    size_t plainTextSize;
+    TSS2_RC r = open_read_and_close (ctx.plainText, (void**)&plainText,
+        &plainTextSize);
+    if (r){
+        LOG_PERR ("open_read_and_close plainText", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *cipherText;
+    size_t cipherTextSize;
+    r = Fapi_Encrypt (fctx, ctx.keyPath, plainText, plainTextSize,
+        &cipherText, &cipherTextSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Encrypt", r);
+        free (plainText);
+        return 1;
+    }
+    free (plainText);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.cipherText, ctx.overwrite, cipherText,
+        cipherTextSize);
+    if (r) {
+        LOG_PERR ("open_write_and_close cipherText", r);
+        return 1;
+    }
+
+    Fapi_Free (cipherText);
+    return 0;
+}

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -23,16 +23,16 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'p':
+    case 'P':
         ctx.policyPath = value;
         break;
-    case 'c':
+    case 'o':
         ctx.cipherText = value;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
-    case 'P':
+    case 'i':
         ctx.plainText = value;
         break;
     }
@@ -42,13 +42,13 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
-        {"policyPath",  required_argument, NULL, 'p'},
-        {"plainText",   required_argument, NULL, 'P'},
-        {"cipherText",  required_argument, NULL, 'c'},
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"policyPath",  required_argument, NULL, 'P'},
+        {"plainText",   required_argument, NULL, 'i'},
+        {"cipherText",  required_argument, NULL, 'o'},
         {"force",       no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("f:p:c:k:P:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:P:o:p:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -56,17 +56,15 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
-        fprintf (stderr, "No key path provided, use --keyPath=\n");
+        fprintf (stderr, "No key path provided, use --keyPath\n");
         return -1;
     }
     if (!ctx.plainText) {
-        fprintf (stderr, "No text to encrypt provided, use --plainText=[file" \
-            ", or '-' for standard input]\n");
+        fprintf (stderr, "No text to encrypt provided, use --plainText\n");
         return -1;
     }
     if (!ctx.cipherText) {
-        fprintf (stderr, "No output file provided, --cipherText=[file, or " \
-            "'-' for standard output]\n");
+        fprintf (stderr, "No output file provided, --cipherText\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *pathOfKeyToDuplicate;
+    char const *pathToPublicKeyOfNewParent;
+    char const *exportedData;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'e':
+        ctx.pathToPublicKeyOfNewParent = value;
+        break;
+    case 'o':
+        ctx.exportedData = value;
+        break;
+    case 'p':
+        ctx.pathOfKeyToDuplicate = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'e'},
+        {"force",                       no_argument      , NULL, 'f'},
+        {"exportedData",                required_argument, NULL, 'o'},
+        {"pathOfKeyToDuplicate",        required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("f:e:o:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.exportedData) {
+        fprintf (stderr, "exported data missing, use --output\n");
+        return -1;
+    }
+    if (!ctx.pathOfKeyToDuplicate) {
+        fprintf (stderr, "path of key to duplicate missing, use --path\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *exportedData;
+    TSS2_RC r = Fapi_ExportKey (fctx, ctx.pathOfKeyToDuplicate,
+        ctx.pathToPublicKeyOfNewParent, &exportedData);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_ExportKey", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.exportedData, ctx.overwrite, exportedData,
+        strlen(exportedData));
+    if (r){
+        LOG_PERR ("open_write_and_close exportedData", r);
+        Fapi_Free (exportedData);
+        return 1;
+    }
+
+    Fapi_Free (exportedData);
+    return 0;
+}

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *pathOfKeyToDuplicate;
+    char const *pathToPublicKeyOfNewParent;
+    char const *exportedData;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'P':
+        ctx.pathToPublicKeyOfNewParent = value;
+        break;
+    case 'e':
+        ctx.exportedData = value;
+        break;
+    case 'p':
+        ctx.pathOfKeyToDuplicate = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'P'},
+        {"force",                       no_argument      , NULL, 'f'},
+        {"exportedData",                required_argument, NULL, 'e'},
+        {"pathOfKeyToDuplicate",        required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("f:P:e:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.exportedData) {
+        fprintf (stderr, "exported data missing, use --output=\n");
+        return -1;
+    }
+    if (!ctx.pathOfKeyToDuplicate) {
+        fprintf (stderr, "path of key to duplicate missing, use --path=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *exportedData;
+    TSS2_RC r = Fapi_ExportKey (fctx, ctx.pathOfKeyToDuplicate,
+        ctx.pathToPublicKeyOfNewParent, &exportedData);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_ExportKey", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.exportedData, ctx.overwrite, exportedData,
+        strlen(exportedData));
+    if (r){
+        LOG_PERR ("open_write_and_close exportedData", r);
+        Fapi_Free (exportedData);
+        return 1;
+    }
+
+    Fapi_Free (exportedData);
+    return 0;
+}

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -23,10 +23,10 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'P':
+    case 'e':
         ctx.pathToPublicKeyOfNewParent = value;
         break;
-    case 'e':
+    case 'o':
         ctx.exportedData = value;
         break;
     case 'p':
@@ -39,12 +39,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'P'},
+        {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'e'},
         {"force",                       no_argument      , NULL, 'f'},
-        {"exportedData",                required_argument, NULL, 'e'},
+        {"exportedData",                required_argument, NULL, 'o'},
         {"pathOfKeyToDuplicate",        required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("f:P:e:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:e:o:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -52,11 +52,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.exportedData) {
-        fprintf (stderr, "exported data missing, use --output=\n");
+        fprintf (stderr, "exported data missing, use --output\n");
         return -1;
     }
     if (!ctx.pathOfKeyToDuplicate) {
-        fprintf (stderr, "path of key to duplicate missing, use --path=\n");
+        fprintf (stderr, "path of key to duplicate missing, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *path;
+    char *jsonPolicy;
+    bool overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'o':
+        ctx.jsonPolicy = value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force",       no_argument      , NULL, 'f'},
+        {"path",        required_argument, NULL, 'p'},
+        {"jsonPolicy",  required_argument, NULL, 'o'},
+
+    };
+    return (*opts = tpm2_options_new ("f:o:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path parameter is missing, pass --path\n");
+        return -1;
+    }
+    if (!ctx.jsonPolicy) {
+        fprintf (stderr, "parameter jsonPolicy is missing, pass --jsonPolicy\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *jsonPolicy;
+    TSS2_RC r = Fapi_ExportPolicy (fctx, ctx.path, &jsonPolicy);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_PolicyExport", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.jsonPolicy, ctx.overwrite, jsonPolicy, 0);
+    if (r){
+        LOG_PERR ("open_write_and_close buffer", r);
+        return 1;
+    }
+
+    Fapi_Free (jsonPolicy);
+    return 0;
+}

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *path;
+    char *buffer;
+    bool overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'j':
+        ctx.buffer = value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force",       no_argument      , NULL, 'f'},
+        {"path",        required_argument, NULL, 'p'},
+        {"jsonPolicy",  required_argument, NULL, 'j'},
+
+    };
+    return (*opts = tpm2_options_new ("f:j:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path parameter is missing, pass --path=\n");
+        return -1;
+    }
+    if (!ctx.buffer) {
+        fprintf (stderr, "output parameter is missing, pass --jsonPolicy=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *buffer;
+    TSS2_RC r = Fapi_ExportPolicy (fctx, ctx.path, &buffer);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_PolicyExport", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.buffer, ctx.overwrite, buffer, 0);
+    if (r){
+        LOG_PERR ("open_write_and_close buffer", r);
+        return 1;
+    }
+
+    Fapi_Free (buffer);
+    return 0;
+}

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -20,7 +20,7 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'a':
+    case 'o':
         ctx.data = value;
         break;
     case 'f':
@@ -37,11 +37,11 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path", required_argument, NULL, 'p'},
-        {"appData", required_argument, NULL, 'a'},
+        {"appData", required_argument, NULL, 'o'},
         {"force" , no_argument, NULL, 'f'},
 
     };
-    return (*opts = tpm2_options_new ("a:f:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -49,7 +49,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *data;
+    char const *path;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'o':
+        ctx.data = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path", required_argument, NULL, 'p'},
+        {"appData", required_argument, NULL, 'o'},
+        {"force" , no_argument, NULL, 'f'},
+
+    };
+    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path\n");
+        return -1;
+    }
+
+    /* Initialize return variables */
+    uint8_t *appData;
+    size_t appDataSize;
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_GetAppData (fctx, ctx.path, &appData, &appDataSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetAppData", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.data, ctx.overwrite, appData, appDataSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("open_write_and_close appData", r);
+        return 1;
+    }
+
+   /* Free allocated variables */
+    Fapi_Free (appData);
+    return 0;
+}

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *data;
+    char const *path;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.data = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path", required_argument, NULL, 'p'},
+        {"appData", required_argument, NULL, 'a'},
+        {"force" , no_argument, NULL, 'f'},
+
+    };
+    return (*opts = tpm2_options_new ("a:f:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path=\n");
+        return -1;
+    }
+
+    /* Initialize return variables */
+    uint8_t *appData;
+    size_t appDataSize;
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_GetAppData (fctx, ctx.path, &appData, &appDataSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetAppData", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.data, ctx.overwrite, appData, appDataSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("open_write_and_close appData", r);
+        return 1;
+    }
+
+   /* Free allocated variables */
+    Fapi_Free (appData);
+    return 0;
+}

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *x509cert;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'x':
+        ctx.x509cert = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
+        {"path"    , required_argument, NULL, 'p'},
+        {"x509certData", required_argument, NULL, 'x'}
+    };
+    return (*opts = tpm2_options_new ("f:p:x:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path missing, use --path=\n");
+        return -1;
+    }
+    if (!ctx.x509cert) {
+        fprintf (stderr, "x509certData missing, use --x509certData=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *x509certData;
+    TSS2_RC r = Fapi_GetCertificate (fctx, ctx.path, &x509certData);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetCertificate", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.x509cert, ctx.overwrite, x509certData,
+        strlen(x509certData));
+    if (r){
+        LOG_PERR ("open_read_and_close x509certData", r);
+        Fapi_Free (x509certData);
+        return 1;
+    }
+    Fapi_Free (x509certData);
+
+    return 0;
+}

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -25,7 +25,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.path = value;
         break;
-    case 'x':
+    case 'o':
         ctx.x509cert = value;
         break;
     }
@@ -37,9 +37,9 @@ bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         {"path"    , required_argument, NULL, 'p'},
-        {"x509certData", required_argument, NULL, 'x'}
+        {"x509certData", required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:p:x:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:p:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,11 +47,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path missing, use --path=\n");
+        fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
     if (!ctx.x509cert) {
-        fprintf (stderr, "x509certData missing, use --x509certData=\n");
+        fprintf (stderr, "x509certData missing, use --x509certData\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *x509cert;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'o':
+        ctx.x509cert = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
+        {"path"    , required_argument, NULL, 'p'},
+        {"x509certData", required_argument, NULL, 'o'}
+    };
+    return (*opts = tpm2_options_new ("f:p:o:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path missing, use --path\n");
+        return -1;
+    }
+    if (!ctx.x509cert) {
+        fprintf (stderr, "x509certData missing, use --x509certData\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *x509certData;
+    TSS2_RC r = Fapi_GetCertificate (fctx, ctx.path, &x509certData);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetCertificate", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.x509cert, ctx.overwrite, x509certData,
+        strlen(x509certData));
+    if (r){
+        LOG_PERR ("open_read_and_close x509certData", r);
+        Fapi_Free (x509certData);
+        return 1;
+    }
+    Fapi_Free (x509certData);
+
+    return 0;
+}

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *description;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'd':
+        ctx.description = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path"        , required_argument, NULL, 'p'},
+        {"description" , required_argument, NULL, 'd'},
+        {"force"       , no_argument      , NULL, 'f'},
+    };
+    return (*opts = tpm2_options_new ("d:f:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path=\n");
+        return -1;
+    }
+    if (!ctx.description) {
+        fprintf (stderr, "description is missing, use --description=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *description;
+    TSS2_RC r = Fapi_GetDescription (fctx, ctx.path, &description);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetDescription", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.description, ctx.overwrite, description,
+        strlen(description));
+    if (r){
+        LOG_PERR ("open_read_and_close description", r);
+        Fapi_Free (description);
+        return 1;
+    }
+    Fapi_Free (description);
+
+    return 0;
+}

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *description;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'o':
+        ctx.description = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path"        , required_argument, NULL, 'p'},
+        {"description" , required_argument, NULL, 'o'},
+        {"force"       , no_argument      , NULL, 'f'},
+    };
+    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path\n");
+        return -1;
+    }
+    if (!ctx.description) {
+        fprintf (stderr, "description is missing, use --description\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    char *description;
+    TSS2_RC r = Fapi_GetDescription (fctx, ctx.path, &description);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetDescription", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.description, ctx.overwrite, description,
+        strlen(description));
+    if (r){
+        LOG_PERR ("open_read_and_close description", r);
+        Fapi_Free (description);
+        return 1;
+    }
+    Fapi_Free (description);
+
+    return 0;
+}

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -22,7 +22,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.path = value;
         break;
-    case 'd':
+    case 'o':
         ctx.description = value;
         break;
     case 'f':
@@ -36,10 +36,10 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"        , required_argument, NULL, 'p'},
-        {"description" , required_argument, NULL, 'd'},
+        {"description" , required_argument, NULL, 'o'},
         {"force"       , no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("d:f:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,11 +47,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
     if (!ctx.description) {
-        fprintf (stderr, "description is missing, use --description=\n");
+        fprintf (stderr, "description is missing, use --description\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char *info;
+    bool  overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'o':
+        ctx.info = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
+        /* output file */
+        {"info"  , required_argument, NULL, 'o'}
+    };
+    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Execute FAPI command with passed arguments */
+    char *info;
+    TSS2_RC r = Fapi_GetInfo (fctx, &info);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetInfo", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.info, ctx.overwrite, info, 0);
+    if (r) {
+        LOG_PERR ("open_write_and_close", r);
+        Fapi_Free (info);
+        return 1;
+    }
+
+    Fapi_Free (info);
+    return 0;
+}

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -10,7 +10,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
-    char *filename;
+    char *info;
     bool  overwrite;
 } ctx;
 
@@ -20,8 +20,8 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'i':
-        ctx.filename = value;
+    case 'o':
+        ctx.info = value;
         break;
     }
     return true;
@@ -32,30 +32,30 @@ bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         /* output file */
-        {"info"  , required_argument, NULL, 'i'}
+        {"info"  , required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:i:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Execute FAPI command with passed arguments */
-    char *output;
-    TSS2_RC r = Fapi_GetInfo (fctx, &output);
+    char *info;
+    TSS2_RC r = Fapi_GetInfo (fctx, &info);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_GetInfo", r);
         return 1;
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.filename, ctx.overwrite, output, 0);
+    r = open_write_and_close (ctx.info, ctx.overwrite, info, 0);
     if (r) {
         LOG_PERR ("open_write_and_close", r);
-        Fapi_Free (output);
+        Fapi_Free (info);
         return 1;
     }
 
-    Fapi_Free (output);
+    Fapi_Free (info);
     return 0;
 }

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char *filename;
+    bool  overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'i':
+        ctx.filename = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
+        /* output file */
+        {"info"  , required_argument, NULL, 'i'}
+    };
+    return (*opts = tpm2_options_new ("f:i:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Execute FAPI command with passed arguments */
+    char *output;
+    TSS2_RC r = Fapi_GetInfo (fctx, &output);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetInfo", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.filename, ctx.overwrite, output, 0);
+    if (r) {
+        LOG_PERR ("open_write_and_close", r);
+        Fapi_Free (output);
+        return 1;
+    }
+
+    Fapi_Free (output);
+    return 0;
+}

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -21,7 +21,7 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'c':
+    case 'o':
         ctx.certificates = value;
         break;
     }
@@ -32,9 +32,9 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force",           no_argument      , NULL, 'f'},
-        {"certificates",    required_argument, NULL, 'c'}
+        {"certificates",    required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:c:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -42,7 +42,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.certificates) {
-        fprintf (stderr, "certificates missing, use --certificates=\n");
+        fprintf (stderr, "certificates missing, use --certificates\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *certificates;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'o':
+        ctx.certificates = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force",           no_argument      , NULL, 'f'},
+        {"certificates",    required_argument, NULL, 'o'}
+    };
+    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.certificates) {
+        fprintf (stderr, "certificates missing, use --certificates\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *certificates;
+    size_t  certificatesSize = 0;
+    TSS2_RC r = Fapi_GetPlatformCertificates (fctx, &certificates,
+        &certificatesSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetPlatformCertificates", r);
+        if (certificatesSize>0){
+            Fapi_Free (certificates);
+        }
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    if (certificatesSize>0){
+        r = open_write_and_close (ctx.certificates, ctx.overwrite,
+            certificates, certificatesSize);
+        if (r){
+            LOG_PERR ("open_write_and_close certificates", r);
+            Fapi_Free (certificates);
+            return 1;
+        }
+        Fapi_Free (certificates);
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *certificates;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'c':
+        ctx.certificates = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force",           no_argument      , NULL, 'f'},
+        {"certificates",    required_argument, NULL, 'c'}
+    };
+    return (*opts = tpm2_options_new ("f:c:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.certificates) {
+        fprintf (stderr, "certificates missing, use --certificates=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *certificates;
+    size_t  certificatesSize = 0;
+    TSS2_RC r = Fapi_GetPlatformCertificates (fctx, &certificates,
+        &certificatesSize);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetPlatformCertificates", r);
+        if(certificatesSize>0){
+            Fapi_Free (certificates);
+        }
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    if(certificatesSize>0){
+        r = open_write_and_close (ctx.certificates, ctx.overwrite,
+            certificates, certificatesSize);
+        if(r){
+            LOG_PERR ("open_write_and_close certificates", r);
+            Fapi_Free (certificates);
+            return 1;
+        }
+        Fapi_Free (certificates);
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -53,17 +53,17 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         &certificatesSize);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_GetPlatformCertificates", r);
-        if(certificatesSize>0){
+        if (certificatesSize>0){
             Fapi_Free (certificates);
         }
         return 1;
     }
 
     /* Write returned data to file(s) */
-    if(certificatesSize>0){
+    if (certificatesSize>0){
         r = open_write_and_close (ctx.certificates, ctx.overwrite,
             certificates, certificatesSize);
-        if(r){
+        if (r){
             LOG_PERR ("open_write_and_close certificates", r);
             Fapi_Free (certificates);
             return 1;

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -78,7 +78,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.filename, ctx.overwrite, output,
         ctx.numBytes);
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close output", r);
         Fapi_Free (output);
         return 1;

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    size_t  numBytes;
+    char   *filename;
+    bool    overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'n': {
+        /*N.B. In theory size_t can be unsigned long, which is more than
+         * uint32, in practice this will never happen */
+        uint32_t i;
+        if (!tpm2_util_string_to_uint32 (value, &i) || i == 0) {
+            fprintf (stderr, "%s cannot be converted to a positive integer or "\
+                "is larger than 2**32 - 1\n", value);
+            return false;
+        }
+        ctx.numBytes = i; /* cast from uint32 to size_t */
+        }
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'o':
+        ctx.filename = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"numBytes", required_argument, NULL, 'n'},
+        {"force"    , no_argument      , NULL, 'f'},
+        /* output file */
+        {"data"   , required_argument, NULL, 'o'}
+    };
+    return (*opts = tpm2_options_new ("f:n:o:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.filename) {
+        fprintf (stderr, "No filename for data was provided, use --data\n");
+        return -1;
+    }
+    if (!ctx.numBytes) {
+        fprintf (stderr, "No amount of bytes was provided, use --numBytes\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *data;
+    TSS2_RC r = Fapi_GetRandom (fctx, ctx.numBytes, &data);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetRandom", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.filename, ctx.overwrite, data,
+        ctx.numBytes);
+    if (r){
+        LOG_PERR ("open_write_and_close output", r);
+        Fapi_Free (data);
+        return 1;
+    }
+
+    Fapi_Free (data);
+    return r;
+}

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    size_t  numBytes;
+    char   *filename;
+    bool    overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'n': {
+        /*N.B. In theory size_t can be unsigned long, which is more than
+         * uint32, in practice this will never happen */
+        uint32_t i;
+        if (!tpm2_util_string_to_uint32 (value, &i) || i == 0) {
+            fprintf (stderr, "%s cannot be converted to a positive integer or "\
+                "is larger than 2**32 - 1\n", value);
+            return false;
+        }
+        ctx.numBytes = i; /* cast from uint32 to size_t */
+        }
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'd':
+        ctx.filename = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"numBytes", required_argument, NULL, 'n'},
+        {"force"    , no_argument      , NULL, 'f'},
+        /* output file */
+        {"data"   , required_argument, NULL, 'd'}
+    };
+    return (*opts = tpm2_options_new ("f:n:d:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.filename) {
+        fprintf (stderr, "No filename for output was provided, use --data "\
+            "[filename], or --data - for printing to stdout\n");
+        return -1;
+    }
+    if (!ctx.numBytes) {
+        fprintf (stderr, "No amount of bytes was provided, use --numBytes "\
+            "[positive integer less than 2**32]\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *output;
+    TSS2_RC r = Fapi_GetRandom (fctx, ctx.numBytes, &output);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetRandom", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.filename, ctx.overwrite, output,
+        ctx.numBytes);
+    if(r){
+        LOG_PERR ("open_write_and_close output", r);
+        Fapi_Free (output);
+        return 1;
+    }
+
+    Fapi_Free (output);
+    return r;
+}

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *tpm2bPublic;
+    char const *tpm2bPrivate;
+    char const *policy;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'u':
+        ctx.tpm2bPublic = value;
+        break;
+    case 'r':
+        ctx.tpm2bPrivate = value;
+        break;
+    case 'l':
+        ctx.policy = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
+        {"path"    , required_argument, NULL, 'p'},
+        {"tpm2bPublic"    , required_argument, NULL, 'u'},
+        {"tpm2bPrivate"    , required_argument, NULL, 'r'},
+        {"policy"    , required_argument, NULL, 'l'},
+    };
+    return (*opts = tpm2_options_new ("f:p:u:r:l", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path missing, use --path=\n");
+        return -1;
+    }
+    if (!ctx.tpm2bPublic) {
+        fprintf (stderr, "public missing, use --tpm2bPublic=\n");
+        return -1;
+    }
+    if (!ctx.tpm2bPrivate) {
+        fprintf (stderr, "private missing, use --tpm2bPrivate=\n");
+        return -1;
+    }
+    if (!ctx.policy) {
+        fprintf (stderr, "policy missing, use --policy=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *tpm2bPublic;
+    size_t  tpm2bPublicSize;
+    uint8_t *tpm2bPrivate;
+    size_t  tpm2bPrivateSize;
+    char *policy = NULL;
+    TSS2_RC r = Fapi_GetTpmBlobs (fctx, ctx.path, &tpm2bPublic,
+        &tpm2bPublicSize, &tpm2bPrivate, &tpm2bPrivateSize, &policy);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetTpmBlobs", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.tpm2bPublic, ctx.overwrite, tpm2bPublic,
+        tpm2bPublicSize);
+    if (r){
+        LOG_PERR ("open_write_and_close tpm2bPublic", r);
+        return 1;
+    }
+    r = open_write_and_close (ctx.tpm2bPrivate, ctx.overwrite, tpm2bPrivate,
+        tpm2bPrivateSize);
+    if (r){
+        LOG_PERR ("open_write_and_close tpm2bPrivate", r);
+        Fapi_Free (tpm2bPublic);
+        return 1;
+    }
+    if(policy){
+        r = open_write_and_close (ctx.policy, ctx.overwrite, policy,
+            strlen(policy));
+        if (r){
+            LOG_PERR ("open_write_and_close policy", r);
+            Fapi_Free (tpm2bPublic);
+            Fapi_Free (tpm2bPrivate);
+            return 1;
+        }
+        Fapi_Free(policy);
+    }
+
+    Fapi_Free (tpm2bPublic);
+    Fapi_Free (tpm2bPrivate);
+    return 0;
+}

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -100,7 +100,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         Fapi_Free (tpm2bPublic);
         return 1;
     }
-    if(policy){
+    if (policy){
         r = open_write_and_close (ctx.policy, ctx.overwrite, policy,
             strlen(policy));
         if (r){

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -57,19 +57,19 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path missing, use --path=\n");
+        fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
     if (!ctx.tpm2bPublic) {
-        fprintf (stderr, "public missing, use --tpm2bPublic=\n");
+        fprintf (stderr, "public missing, use --tpm2bPublic\n");
         return -1;
     }
     if (!ctx.tpm2bPrivate) {
-        fprintf (stderr, "private missing, use --tpm2bPrivate=\n");
+        fprintf (stderr, "private missing, use --tpm2bPrivate\n");
         return -1;
     }
     if (!ctx.policy) {
-        fprintf (stderr, "policy missing, use --policy=\n");
+        fprintf (stderr, "policy missing, use --policy\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *tpm2bPublic;
+    char const *tpm2bPrivate;
+    char const *policy;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'u':
+        ctx.tpm2bPublic = value;
+        break;
+    case 'r':
+        ctx.tpm2bPrivate = value;
+        break;
+    case 'l':
+        ctx.policy = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
+        {"path"    , required_argument, NULL, 'p'},
+        {"tpm2bPublic"    , required_argument, NULL, 'u'},
+        {"tpm2bPrivate"    , required_argument, NULL, 'r'},
+        {"policy"    , required_argument, NULL, 'l'},
+    };
+    return (*opts = tpm2_options_new ("f:p:u:r:l", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path missing, use --path\n");
+        return -1;
+    }
+    if (!ctx.tpm2bPublic) {
+        fprintf (stderr, "public missing, use --tpm2bPublic\n");
+        return -1;
+    }
+    if (!ctx.tpm2bPrivate) {
+        fprintf (stderr, "private missing, use --tpm2bPrivate\n");
+        return -1;
+    }
+    if (!ctx.policy) {
+        fprintf (stderr, "policy missing, use --policy\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *tpm2bPublic;
+    size_t  tpm2bPublicSize;
+    uint8_t *tpm2bPrivate;
+    size_t  tpm2bPrivateSize;
+    char *policy = NULL;
+    TSS2_RC r = Fapi_GetTpmBlobs (fctx, ctx.path, &tpm2bPublic,
+        &tpm2bPublicSize, &tpm2bPrivate, &tpm2bPrivateSize, &policy);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetTpmBlobs", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.tpm2bPublic, ctx.overwrite, tpm2bPublic,
+        tpm2bPublicSize);
+    if (r){
+        LOG_PERR ("open_write_and_close tpm2bPublic", r);
+        return 1;
+    }
+    r = open_write_and_close (ctx.tpm2bPrivate, ctx.overwrite, tpm2bPrivate,
+        tpm2bPrivateSize);
+    if (r){
+        LOG_PERR ("open_write_and_close tpm2bPrivate", r);
+        Fapi_Free (tpm2bPublic);
+        return 1;
+    }
+    if (policy){
+        r = open_write_and_close (ctx.policy, ctx.overwrite, policy,
+            strlen(policy));
+        if (r){
+            LOG_PERR ("open_write_and_close policy", r);
+            Fapi_Free (tpm2bPublic);
+            Fapi_Free (tpm2bPrivate);
+            return 1;
+        }
+        Fapi_Free(policy);
+    }
+
+    Fapi_Free (tpm2bPublic);
+    Fapi_Free (tpm2bPrivate);
+    return 0;
+}

--- a/tools/fapi/tss2_import.c
+++ b/tools/fapi/tss2_import.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *path;
+    char *data;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'd':
+        ctx.data = value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"importData", required_argument, NULL, 'd'},
+        {"path"  , required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("d:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path parameter is missing, pass --path=\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "data parameter is missing, pass --importData=\n");
+        return -1;
+    }
+
+    /* Read file to import */
+    char *input;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&input, NULL);
+    if (r){
+        LOG_PERR("open_read_and_close input", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_Import (fctx, ctx.path, input);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_Import", r);
+        Fapi_Free (input);
+        return 1;
+    }
+
+    Fapi_Free (input);
+
+    return 0;
+}

--- a/tools/fapi/tss2_import.c
+++ b/tools/fapi/tss2_import.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *path;
+    char *importData;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i':
+        ctx.importData = value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"importData", required_argument, NULL, 'i'},
+        {"path"  , required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path parameter is missing, pass --path\n");
+        return -1;
+    }
+    if (!ctx.importData) {
+        fprintf (stderr, "importData parameter is missing, pass --importData\n");
+        return -1;
+    }
+
+    /* Read file to import */
+    char *importData;
+    TSS2_RC r = open_read_and_close (ctx.importData, (void**)&importData, NULL);
+    if (r){
+        LOG_PERR("open_read_and_close input", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_Import (fctx, ctx.path, importData);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_Import", r);
+        Fapi_Free (importData);
+        return 1;
+    }
+
+    Fapi_Free (importData);
+
+    return 0;
+}

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 's':
+    case 'p':
         ctx.searchPath = value;
         break;
-    case 'p':
+    case 'o':
         ctx.pathList = value ? value : "-";
         break;
     }
@@ -31,10 +31,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"searchPath" , optional_argument, NULL, 's'},
-        {"pathList" , optional_argument, NULL, 'p'}
+        {"searchPath" , optional_argument, NULL, 'p'},
+        {"pathList" , optional_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("s:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -42,23 +42,23 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     (void) fctx;
     /* Execute FAPI command with passed arguments */
-    char *pathlist = NULL;
+    char *pathList = NULL;
     TSS2_RC r = Fapi_List(fctx,
-        ctx.searchPath ? ctx.searchPath : "", &pathlist);
+        ctx.searchPath ? ctx.searchPath : "", &pathList);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_List", r);
         return 1;
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.pathList, true, pathlist,
-        strlen(pathlist));
+    r = open_write_and_close (ctx.pathList, true, pathList,
+        strlen(pathList));
     if (r){
-        LOG_PERR ("open_write_and_close pathlist", r);
-        Fapi_Free (pathlist);
+        LOG_PERR ("open_write_and_close pathList", r);
+        Fapi_Free (pathList);
         return 1;
     }
 
-    Fapi_Free (pathlist);
+    Fapi_Free (pathList);
     return 0;
 }

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *searchPath;
+    char *pathList;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 's':
+        ctx.searchPath = value;
+        break;
+    case 'p':
+        ctx.pathList = value ? value : "-";
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"searchPath" , optional_argument, NULL, 's'},
+        {"pathList" , optional_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("s:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    (void) fctx;
+    /* Execute FAPI command with passed arguments */
+    char *pathlist = NULL;
+    TSS2_RC r = Fapi_List(fctx,
+        ctx.searchPath ? ctx.searchPath : "", &pathlist);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_List", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.pathList, true, pathlist,
+        strlen(pathlist));
+    if (r){
+        LOG_PERR ("open_write_and_close pathlist", r);
+        Fapi_Free (pathlist);
+        return 1;
+    }
+
+    Fapi_Free (pathlist);
+    return 0;
+}

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *searchPath;
+    char *pathList;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.searchPath = value;
+        break;
+    case 'o':
+        ctx.pathList = value ? value : "-";
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"searchPath" , optional_argument, NULL, 'p'},
+        {"pathList" , optional_argument, NULL, 'o'}
+    };
+    return (*opts = tpm2_options_new ("p:o:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    (void) fctx;
+    /* Execute FAPI command with passed arguments */
+    char *pathList = NULL;
+    TSS2_RC r = Fapi_List(fctx,
+        ctx.searchPath ? ctx.searchPath : "", &pathList);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_List", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.pathList, true, pathList,
+        strlen(pathList));
+    if (r){
+        LOG_PERR ("open_write_and_close pathList", r);
+        Fapi_Free (pathList);
+        return 1;
+    }
+
+    Fapi_Free (pathList);
+    return 0;
+}

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -65,7 +65,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     char *logData = NULL;
-    if(ctx.logData){
+    if (ctx.logData){
         TSS2_RC r = open_read_and_close (ctx.logData, (void**)&logData, 0);
         if (r){
             LOG_PERR ("open_read_and_close logData", r);
@@ -81,7 +81,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
     Fapi_Free (data);
-    if(logData){
+    if (logData){
         Fapi_Free (logData);
     }
 

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'd':
+    case 'i':
         ctx.data = value;
         break;
-    case 'n':
+    case 'p':
         ctx.nvPath = value;
         break;
     case 'l':
@@ -34,11 +34,11 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"data"  , required_argument, NULL, 'd'},
-        {"nvPath"  , required_argument, NULL, 'n'},
+        {"data"  , required_argument, NULL, 'i'},
+        {"nvPath"  , required_argument, NULL, 'p'},
         {"logData"  , required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("d:n:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -46,12 +46,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "No file for input provided, use --data=[filename or "\
-            "'-' for standard input]\n");
+        fprintf (stderr, "No file for input provided, use --data\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char   const *nvPath;
+    char   const *data;
+    char   const *logData;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i':
+        ctx.data = value;
+        break;
+    case 'p':
+        ctx.nvPath = value;
+        break;
+    case 'l':
+        ctx.logData = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"data"  , required_argument, NULL, 'i'},
+        {"nvPath"  , required_argument, NULL, 'p'},
+        {"logData"  , required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("i:p:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No file for input provided, use --data\n");
+        return -1;
+    }
+
+    /* Read data to extend from file */
+    uint8_t *data;
+    size_t data_len;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &data_len);
+    if (r){
+        LOG_PERR ("open_read_and_close data", r);
+        return 1;
+    }
+
+    char *logData = NULL;
+    if (ctx.logData){
+        TSS2_RC r = open_read_and_close (ctx.logData, (void**)&logData, 0);
+        if (r){
+            LOG_PERR ("open_read_and_close logData", r);
+            return 1;
+        }
+    }
+
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_NvExtend(fctx, ctx.nvPath, data, data_len, logData);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_NvExtend", r);
+        return 1;
+    }
+    Fapi_Free (data);
+    if (logData){
+        Fapi_Free (logData);
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char   const *nvPath;
+    char   const *data;
+    char   const *logData;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'd':
+        ctx.data = value;
+        break;
+    case 'n':
+        ctx.nvPath = value;
+        break;
+    case 'l':
+        ctx.logData = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"data"  , required_argument, NULL, 'd'},
+        {"nvPath"  , required_argument, NULL, 'n'},
+        {"logData"  , required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("d:n:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No file for input provided, use --data=[filename or "\
+            "'-' for standard input]\n");
+        return -1;
+    }
+
+    /* Read data to extend from file */
+    uint8_t *data;
+    size_t data_len;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &data_len);
+    if (r){
+        LOG_PERR ("open_read_and_close data", r);
+        return 1;
+    }
+
+    char *logData = NULL;
+    if(ctx.logData){
+        TSS2_RC r = open_read_and_close (ctx.logData, (void**)&logData, 0);
+        if (r){
+            LOG_PERR ("open_read_and_close logData", r);
+            return 1;
+        }
+    }
+
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_NvExtend(fctx, ctx.nvPath, data, data_len, logData);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_NvExtend", r);
+        return 1;
+    }
+    Fapi_Free (data);
+    if(logData){
+        Fapi_Free (logData);
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_nvincrement.c
+++ b/tools/fapi/tss2_nvincrement.c
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Variable used to store passed command line parameter */
+static char const *nvPath;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        nvPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"nvPath", required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!nvPath) {
+        fprintf (stderr, "No path to the NV provided, use --nvPath\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_NvIncrement(fctx, nvPath);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_NV_Increment", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_nvincrement.c
+++ b/tools/fapi/tss2_nvincrement.c
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Variable used to store passed command line parameter */
+static char const *nvPath;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'n':
+        nvPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"nvPath", required_argument, NULL, 'n'}
+    };
+    return (*opts = tpm2_options_new ("n:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!nvPath) {
+        fprintf (stderr, "No path to the NV provided, use --nvPath=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_NvIncrement(fctx, nvPath);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_NV_Increment", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_nvincrement.c
+++ b/tools/fapi/tss2_nvincrement.c
@@ -13,7 +13,7 @@ static char const *nvPath;
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'n':
+    case 'p':
         nvPath = value;
         break;
     }
@@ -23,9 +23,9 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"nvPath", required_argument, NULL, 'n'}
+        {"nvPath", required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("n:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -33,7 +33,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!nvPath) {
-        fprintf (stderr, "No path to the NV provided, use --nvPath=\n");
+        fprintf (stderr, "No path to the NV provided, use --nvPath\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -78,7 +78,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             LOG_PERR ("open_write_and_close data", r);
             return 1;
         }
-        if(logData){
+        if (logData){
             r = open_write_and_close (ctx.logData, ctx.overwrite, logData, strlen(logData));
             if (r){
                 Fapi_Free (data);

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -24,10 +24,10 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'd':
+    case 'o':
         ctx.data = value;
         break;
-    case 'n':
+    case 'p':
         ctx.nvPath = value;
         break;
     case 'l':
@@ -40,12 +40,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"nvPath"  , required_argument, NULL, 'n'},
+        {"nvPath"  , required_argument, NULL, 'p'},
         {"force" , no_argument      , NULL, 'f'},
-        {"data", required_argument, NULL, 'd'},
+        {"data", required_argument, NULL, 'o'},
         {"logData", required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("f:d:n:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("f:o:p:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -53,12 +53,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "No file for output provided, use --data=[filename "\
-            "or '-' for standard output]\n");
+        fprintf (stderr, "No file for output provided, use --data\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *nvPath;
+    char const *data;
+    char const *logData;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'o':
+        ctx.data = value;
+        break;
+    case 'p':
+        ctx.nvPath = value;
+        break;
+    case 'l':
+        ctx.logData = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"nvPath"  , required_argument, NULL, 'p'},
+        {"force" , no_argument      , NULL, 'f'},
+        {"data", required_argument, NULL, 'o'},
+        {"logData", required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("f:o:p:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No file for output provided, use --data\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *data;
+    size_t data_len;
+    char *logData = NULL;
+    TSS2_RC r = Fapi_NvRead(fctx, ctx.nvPath, &data, &data_len, &logData);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_NvRead", r);
+        return 1;
+    }
+    else {
+        /* Write returned data to file(s) */
+        r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
+        if (r){
+            LOG_PERR ("open_write_and_close data", r);
+            return 1;
+        }
+        if (logData){
+            r = open_write_and_close (ctx.logData, ctx.overwrite, logData, strlen(logData));
+            if (r){
+                Fapi_Free (data);
+                LOG_PERR ("open_write_and_close logData", r);
+                return 1;
+            }
+            Fapi_Free (logData);
+        }
+        Fapi_Free (data);
+    }
+    return 0;
+}

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *nvPath;
+    char const *data;
+    char const *logData;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'd':
+        ctx.data = value;
+        break;
+    case 'n':
+        ctx.nvPath = value;
+        break;
+    case 'l':
+        ctx.logData = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"nvPath"  , required_argument, NULL, 'n'},
+        {"force" , no_argument      , NULL, 'f'},
+        {"data", required_argument, NULL, 'd'},
+        {"logData", required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("f:d:n:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No file for output provided, use --data=[filename "\
+            "or '-' for standard output]\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *data;
+    size_t data_len;
+    char *logData = NULL;
+    TSS2_RC r = Fapi_NvRead(fctx, ctx.nvPath, &data, &data_len, &logData);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_NvRead", r);
+        return 1;
+    }
+    else {
+        /* Write returned data to file(s) */
+        r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
+        if (r){
+            LOG_PERR ("open_write_and_close data", r);
+            return 1;
+        }
+        if(logData){
+            r = open_write_and_close (ctx.logData, ctx.overwrite, logData, strlen(logData));
+            if (r){
+                Fapi_Free (data);
+                LOG_PERR ("open_write_and_close logData", r);
+                return 1;
+            }
+            Fapi_Free (logData);
+        }
+        Fapi_Free (data);
+    }
+    return 0;
+}

--- a/tools/fapi/tss2_nvsetbits.c
+++ b/tools/fapi/tss2_nvsetbits.c
@@ -15,8 +15,8 @@ static struct cxt {
 
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
-    switch(key) {
-    case 'b': {
+    switch (key) {
+    case 'i': {
         uint64_t i;
         if (!tpm2_util_string_to_uint64 (value, &i) || i == 0) {
             fprintf (stderr, "%s cannot be converted to a positive integer or "\
@@ -26,7 +26,7 @@ static bool on_option(char key, char *value) {
         ctx.bitmap = i; /* cast from uint32 to size_t */
         }
         break;
-    case 'n':
+    case 'p':
         ctx.path = value;
         break;
     }
@@ -36,10 +36,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"bitmap", required_argument, NULL, 'b'},
-        {"nvPath"    , required_argument, NULL, 'n'}
+        {"bitmap", required_argument, NULL, 'i'},
+        {"nvPath"    , required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("b:n:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -47,11 +47,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "No path to the NV provided, use --nvPath=\n");
+        fprintf (stderr, "No path to the NV provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.bitmap) {
-        fprintf (stderr, "No bits provided, use --bitmap=0x...\n");
+        fprintf (stderr, "No bits provided, use --bitmap [0x...]\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvsetbits.c
+++ b/tools/fapi/tss2_nvsetbits.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char     const *path;
+    uint64_t        bitmap;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i': {
+        uint64_t i;
+        if (!tpm2_util_string_to_uint64 (value, &i) || i == 0) {
+            fprintf (stderr, "%s cannot be converted to a positive integer or "\
+                "is larger than 2**64 - 1\n", value);
+            return false;
+        }
+        ctx.bitmap = i; /* cast from uint32 to size_t */
+        }
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"bitmap", required_argument, NULL, 'i'},
+        {"nvPath"    , required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "No path to the NV provided, use --nvPath\n");
+        return -1;
+    }
+    if (!ctx.bitmap) {
+        fprintf (stderr, "No bits provided, use --bitmap [0x...]\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_NvSetBits(fctx, ctx.path, ctx.bitmap);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_NvSetBits", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_nvsetbits.c
+++ b/tools/fapi/tss2_nvsetbits.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char     const *path;
+    uint64_t        bitmap;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch(key) {
+    case 'b': {
+        uint64_t i;
+        if (!tpm2_util_string_to_uint64 (value, &i) || i == 0) {
+            fprintf (stderr, "%s cannot be converted to a positive integer or "\
+                "is larger than 2**64 - 1\n", value);
+            return false;
+        }
+        ctx.bitmap = i; /* cast from uint32 to size_t */
+        }
+        break;
+    case 'n':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"bitmap", required_argument, NULL, 'b'},
+        {"nvPath"    , required_argument, NULL, 'n'}
+    };
+    return (*opts = tpm2_options_new ("b:n:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "No path to the NV provided, use --nvPath=\n");
+        return -1;
+    }
+    if (!ctx.bitmap) {
+        fprintf (stderr, "No bits provided, use --bitmap=0x...\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_NvSetBits(fctx, ctx.path, ctx.bitmap);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_NvSetBits", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_nvwrite.c
+++ b/tools/fapi/tss2_nvwrite.c
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char   const *nvPath;
+    char   const *data;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'd':
+        ctx.data = value;
+        break;
+    case 'n':
+        ctx.nvPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"data"  , required_argument, NULL, 'd'},
+        {"nvPath"  , required_argument, NULL, 'n'}
+    };
+    return (*opts = tpm2_options_new ("d:n:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No file for output provided, use --data=[filename or"\
+            " '-' for standard output]\n");
+        return -1;
+    }
+
+    /* Read data file */
+    uint8_t *input;
+    size_t input_len;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&input, &input_len);
+    if (r) {
+        LOG_PERR ("open_read_and_close input", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_NvWrite(fctx, ctx.nvPath, input, input_len);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_NvWrite", r);
+        return 1;
+    }
+    Fapi_Free (input);
+    return 0;
+}

--- a/tools/fapi/tss2_nvwrite.c
+++ b/tools/fapi/tss2_nvwrite.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char   const *nvPath;
+    char   const *data;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i':
+        ctx.data = value;
+        break;
+    case 'p':
+        ctx.nvPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"data"  , required_argument, NULL, 'i'},
+        {"nvPath"  , required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No file for output provided, use --data\n");
+        return -1;
+    }
+
+    /* Read data file */
+    uint8_t *data;
+    size_t data_len;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &data_len);
+    if (r) {
+        LOG_PERR ("open_read_and_close data", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_NvWrite(fctx, ctx.nvPath, data, data_len);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_NvWrite", r);
+        return 1;
+    }
+    Fapi_Free (data);
+    return 0;
+}

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    uint32_t        pcr;
+    char     const *eventData;
+    char     const *logData;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch  (key) {
+    case 'c':
+        if (!tpm2_util_string_to_uint32 (value, &ctx.pcr)) {
+            fprintf (stderr, "%s cannot be converted to an integer or is"\
+                "larger than 2**32 - 1\n", value);
+            return false;
+        }
+        break;
+    case 'd':
+        ctx.eventData = value;
+        break;
+    case 'l':
+        ctx.logData = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pcr"       , required_argument, NULL, 'c'},
+        {"data", required_argument, NULL, 'd'},
+        {"logData", required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("c:d:l", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.pcr) {
+        fprintf (stderr, "No pcr provided, use --pcr=\n");
+        return -1;
+    }
+    if (!ctx.eventData) {
+        fprintf (stderr, "No event data provided, use --data=\n");
+        return -1;
+    }
+    if (!ctx.logData) {
+        fprintf (stderr, "No log data provided, use --logData=\n");
+        return -1;
+    }
+
+    /* Read event data and log data from file */
+    uint8_t *eventData;
+    size_t eventDataSize;
+    TSS2_RC r = open_read_and_close (ctx.eventData, (void**)&eventData,
+        &eventDataSize);
+    if (r){
+        LOG_PERR ("open_read_and_close eventData", r);
+        return -1;
+    }
+    char *logData;
+    r = open_read_and_close (ctx.logData, (void**)&logData, 0);
+    if (r){
+        LOG_PERR ("open_read_and_close logData", r);
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_PcrExtend(fctx, ctx.pcr, eventData, eventDataSize, logData);
+    if (r != TSS2_RC_SUCCESS){
+        free (logData);
+        LOG_PERR ("Fapi_PcrExtend", r);
+        return 1;
+    }
+
+    Fapi_Free (eventData);
+    free (logData);
+
+    return 0;
+}

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    uint32_t        pcr;
+    char     const *data;
+    char     const *logData;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch  (key) {
+    case 'x':
+        if (!tpm2_util_string_to_uint32 (value, &ctx.pcr)) {
+            fprintf (stderr, "%s cannot be converted to an integer or is"\
+                "larger than 2**32 - 1\n", value);
+            return false;
+        }
+        break;
+    case 'i':
+        ctx.data = value;
+        break;
+    case 'l':
+        ctx.logData = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pcr"       , required_argument, NULL, 'x'},
+        {"data", required_argument, NULL, 'i'},
+        {"logData", required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("x:i:l", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.pcr) {
+        fprintf (stderr, "No pcr provided, use --pcr\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "No event data provided, use --data\n");
+        return -1;
+    }
+    if (!ctx.logData) {
+        fprintf (stderr, "No log data provided, use --logData\n");
+        return -1;
+    }
+
+    /* Read event data and log data from file */
+    uint8_t *data;
+    size_t eventDataSize;
+    TSS2_RC r = open_read_and_close (ctx.data, (void**)&data,
+        &eventDataSize);
+    if (r){
+        LOG_PERR ("open_read_and_close data", r);
+        return -1;
+    }
+    char *logData;
+    r = open_read_and_close (ctx.logData, (void**)&logData, 0);
+    if (r){
+        LOG_PERR ("open_read_and_close logData", r);
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_PcrExtend(fctx, ctx.pcr, data, eventDataSize, logData);
+    if (r != TSS2_RC_SUCCESS){
+        free (logData);
+        LOG_PERR ("Fapi_PcrExtend", r);
+        return 1;
+    }
+
+    Fapi_Free (data);
+    free (logData);
+
+    return 0;
+}

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    uint32_t        pcrIndex;
+    char     const *pcrValue;
+    char     const *pcrLog;
+    bool            overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'c':
+        ctx.pcrValue = value;
+        break;
+    case 'i':
+        if (!tpm2_util_string_to_uint32 (value, &ctx.pcrIndex)) {
+            fprintf (stderr, "The PCR index must be an integer less than "\
+                "2**32-1\n");
+            return false;
+        }
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'l':
+        ctx.pcrLog = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pcrIndex"     , required_argument, NULL, 'i'},
+        {"pcrValue"     , required_argument, NULL, 'c'},
+        {"force"         , no_argument      , NULL, 'f'},
+        {"pcrLog"       , required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("c:i:f:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.pcrIndex) {
+        fprintf (stderr, "No PCR index provided, use --pcrIndex=\n");
+        return -1;
+    }
+    if (!ctx.pcrValue) {
+        fprintf (stderr, "No PCR value provided, use --pcrValue=\n");
+        return -1;
+    }
+    if (!ctx.pcrLog) {
+        fprintf (stderr, "No PCR log provided, use --pcrLog=\n");
+        return -1;
+    }
+    if (!strcmp (ctx.pcrLog, "-") && !strcmp (ctx.pcrValue, "-")) {
+        fprintf (stderr, "Only one of --pcrLog and --pcrIndex can print to "\
+            "standard output");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *pcrValue;
+    size_t pcrValueSize;
+    char *pcrLog;
+    TSS2_RC r = Fapi_PcrRead (fctx, ctx.pcrIndex, &pcrValue, &pcrValueSize,
+        &pcrLog);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_PcrRead", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.pcrValue, ctx.overwrite, pcrValue,
+        pcrValueSize);
+    if(r){
+        LOG_PERR ("open_write_and_close pcrValue", r);
+        return 1;
+    }
+    if(pcrLog){
+        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
+    }
+    else{
+        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, "", 0);
+    }
+    if(r){
+        LOG_PERR ("open_write_and_close pcrLog", r);
+        Fapi_Free (pcrValue);
+        if(pcrLog){
+            Fapi_Free (pcrLog);
+        }
+        return 1;
+    }
+
+    Fapi_Free (pcrValue);
+    if(pcrLog){
+        Fapi_Free (pcrLog);
+    }
+    return r;
+}

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -20,10 +20,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'c':
+    case 'o':
         ctx.pcrValue = value;
         break;
-    case 'i':
+    case 'x':
         if (!tpm2_util_string_to_uint32 (value, &ctx.pcrIndex)) {
             fprintf (stderr, "The PCR index must be an integer less than "\
                 "2**32-1\n");
@@ -43,12 +43,12 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"pcrIndex"     , required_argument, NULL, 'i'},
-        {"pcrValue"     , required_argument, NULL, 'c'},
+        {"pcrIndex"     , required_argument, NULL, 'x'},
+        {"pcrValue"     , required_argument, NULL, 'o'},
         {"force"         , no_argument      , NULL, 'f'},
         {"pcrLog"       , required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("c:i:f:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:x:f:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -56,15 +56,15 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.pcrIndex) {
-        fprintf (stderr, "No PCR index provided, use --pcrIndex=\n");
+        fprintf (stderr, "No PCR index provided, use --pcrIndex\n");
         return -1;
     }
     if (!ctx.pcrValue) {
-        fprintf (stderr, "No PCR value provided, use --pcrValue=\n");
+        fprintf (stderr, "No PCR value provided, use --pcrValue\n");
         return -1;
     }
     if (!ctx.pcrLog) {
-        fprintf (stderr, "No PCR log provided, use --pcrLog=\n");
+        fprintf (stderr, "No PCR log provided, use --pcrLog\n");
         return -1;
     }
     if (!strcmp (ctx.pcrLog, "-") && !strcmp (ctx.pcrValue, "-")) {
@@ -94,7 +94,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (pcrLog){
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
     }
-    else{
+    else {
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, "", 0);
     }
     if (r){

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    uint32_t        pcrIndex;
+    char     const *pcrValue;
+    char     const *pcrLog;
+    bool            overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'o':
+        ctx.pcrValue = value;
+        break;
+    case 'x':
+        if (!tpm2_util_string_to_uint32 (value, &ctx.pcrIndex)) {
+            fprintf (stderr, "The PCR index must be an integer less than "\
+                "2**32-1\n");
+            return false;
+        }
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'l':
+        ctx.pcrLog = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pcrIndex"     , required_argument, NULL, 'x'},
+        {"pcrValue"     , required_argument, NULL, 'o'},
+        {"force"         , no_argument      , NULL, 'f'},
+        {"pcrLog"       , required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("o:x:f:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.pcrIndex) {
+        fprintf (stderr, "No PCR index provided, use --pcrIndex\n");
+        return -1;
+    }
+    if (!ctx.pcrValue) {
+        fprintf (stderr, "No PCR value provided, use --pcrValue\n");
+        return -1;
+    }
+    if (!ctx.pcrLog) {
+        fprintf (stderr, "No PCR log provided, use --pcrLog\n");
+        return -1;
+    }
+    if (!strcmp (ctx.pcrLog, "-") && !strcmp (ctx.pcrValue, "-")) {
+        fprintf (stderr, "Only one of --pcrLog and --pcrIndex can print to "\
+            "standard output");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *pcrValue;
+    size_t pcrValueSize;
+    char *pcrLog;
+    TSS2_RC r = Fapi_PcrRead (fctx, ctx.pcrIndex, &pcrValue, &pcrValueSize,
+        &pcrLog);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_PcrRead", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.pcrValue, ctx.overwrite, pcrValue,
+        pcrValueSize);
+    if (r){
+        LOG_PERR ("open_write_and_close pcrValue", r);
+        return 1;
+    }
+    if (pcrLog){
+        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
+    }
+    else {
+        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, "", 0);
+    }
+    if (r){
+        LOG_PERR ("open_write_and_close pcrLog", r);
+        Fapi_Free (pcrValue);
+        if (pcrLog){
+            Fapi_Free (pcrLog);
+        }
+        return 1;
+    }
+
+    Fapi_Free (pcrValue);
+    if (pcrLog){
+        Fapi_Free (pcrLog);
+    }
+    return r;
+}

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -87,27 +87,27 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.pcrValue, ctx.overwrite, pcrValue,
         pcrValueSize);
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close pcrValue", r);
         return 1;
     }
-    if(pcrLog){
+    if (pcrLog){
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
     }
     else{
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, "", 0);
     }
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close pcrLog", r);
         Fapi_Free (pcrValue);
-        if(pcrLog){
+        if (pcrLog){
             Fapi_Free (pcrLog);
         }
         return 1;
     }
 
     Fapi_Free (pcrValue);
-    if(pcrLog){
+    if (pcrLog){
         Fapi_Free (pcrLog);
     }
     return r;

--- a/tools/fapi/tss2_provision.c
+++ b/tools/fapi/tss2_provision.c
@@ -16,13 +16,13 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'e':
+    case 'E':
         ctx.authValueEh = value;
         break;
-    case 's':
+    case 'S':
         ctx.authValueSh = value;
         break;
-    case 'l':
+    case 'L':
         ctx.authValueLockout = value;
         break;
     }
@@ -32,11 +32,11 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"authValueEh",         required_argument, NULL, 'e'},
-        {"authValueSh",         required_argument, NULL, 's'},
-        {"authValueLockout",    required_argument, NULL, 'l'},
+        {"authValueEh",         required_argument, NULL, 'E'},
+        {"authValueSh",         required_argument, NULL, 'S'},
+        {"authValueLockout",    required_argument, NULL, 'L'},
     };
-    return (*opts = tpm2_options_new ("e:s:l",
+    return (*opts = tpm2_options_new ("E:S:L",
         ARRAY_LEN(topts), topts, on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_provision.c
+++ b/tools/fapi/tss2_provision.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char *authValueEh;
+    char *authValueSh;
+    char *authValueLockout;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'E':
+        ctx.authValueEh = value;
+        break;
+    case 'S':
+        ctx.authValueSh = value;
+        break;
+    case 'L':
+        ctx.authValueLockout = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"authValueEh",         required_argument, NULL, 'E'},
+        {"authValueSh",         required_argument, NULL, 'S'},
+        {"authValueLockout",    required_argument, NULL, 'L'},
+    };
+    return (*opts = tpm2_options_new ("E:S:L",
+        ARRAY_LEN(topts), topts, on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_Provision (fctx, ctx.authValueEh, ctx.authValueSh,
+        ctx.authValueLockout);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_Provision", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_provision.c
+++ b/tools/fapi/tss2_provision.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char *authValueEh;
+    char *authValueSh;
+    char *authValueLockout;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'e':
+        ctx.authValueEh = value;
+        break;
+    case 's':
+        ctx.authValueSh = value;
+        break;
+    case 'l':
+        ctx.authValueLockout = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"authValueEh",         required_argument, NULL, 'e'},
+        {"authValueSh",         required_argument, NULL, 's'},
+        {"authValueLockout",    required_argument, NULL, 'l'},
+    };
+    return (*opts = tpm2_options_new ("e:s:l",
+        ARRAY_LEN(topts), topts, on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_Provision (fctx, ctx.authValueEh, ctx.authValueSh,
+        ctx.authValueLockout);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_Provision", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -179,10 +179,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
-    if(r){
+    if (r){
         LOG_PERR ("open_write_and_close quoteInfo", r);
         Fapi_Free (quoteInfo);
-        if(pcrEventLog){
+        if (pcrEventLog){
             Fapi_Free (pcrEventLog);
         }
         Fapi_Free (signature);
@@ -191,10 +191,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     Fapi_Free (quoteInfo);
 
-    if(pcrEventLog){
+    if (pcrEventLog){
         r = open_write_and_close (ctx.pcrEventLog, ctx.overwrite, pcrEventLog,
             0);
-        if(r){
+        if (r){
             LOG_PERR ("open_write_and_close pcrEventLog", r);
             Fapi_Free (pcrEventLog);
             Fapi_Free (signature);

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -1,0 +1,225 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    uint32_t   *pcrList;
+    char const *keyPath;
+    char const *qualifyingData;
+    char const *quoteInfo;
+    char const *pcrLog;
+    char const *signature;
+    char const *certificate;
+    bool        overwrite;
+} ctx;
+
+/**
+ * Split the comma separated input, parse each token as number,
+ * put the numbers in the array output.  Allocate memory for
+ * output to hold the numbers.  The last element of output is -1.
+ *
+ * On failure returns false and output is not allocated.
+ * On success the caller frees output.
+ */
+static inline bool extract_pcrs(char *input, uint32_t **output) {
+    size_t size = 1;
+    char *temp = input;
+    while ((temp = strchr (temp+1, ','))) size++;
+    *output = malloc (sizeof(uint32_t) * (size + 1));
+    if (!*output) {
+        fprintf (stderr, "malloc failed: %m\n");
+        return false;
+    }
+    (*output)[size] = -1;
+    char *x = strtok_r (input, ",", &temp);
+    if (!tpm2_util_string_to_uint32(x, output[0])) {
+        fprintf (stderr, "%s cannot be used as PCR\n", x);
+        free (*output);
+        return false;
+    }
+    size = 0;
+    while ((x = strtok_r (NULL, ",", &temp))) {
+      if (!tpm2_util_string_to_uint32(x, &(*output)[++size])) {
+            fprintf (stderr, "%s cannot be used as PCR\n", x);
+            free (*output);
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    (void)value;
+    switch (key) {
+    case 'x':
+        return extract_pcrs(value, &ctx.pcrList);
+    case 'Q':
+        ctx.qualifyingData = value;
+        break;
+    case 'l':
+        ctx.pcrLog = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'q':
+        ctx.quoteInfo = value;
+        break;
+    case 'o':
+        ctx.signature = value;
+        break;
+    case 'c':
+        ctx.certificate = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pcrList"       , required_argument, NULL, 'x'},
+        {"keyPath"        , required_argument, NULL, 'p'},
+        {"qualifyingData", required_argument, NULL, 'Q'},
+        {"quoteInfo"     , required_argument, NULL, 'q'},
+        {"signature"      , required_argument, NULL, 'o'},
+        {"pcrLog"        , required_argument, NULL, 'l'},
+        {"certificate"    , required_argument, NULL, 'c'},
+        {"force"          , no_argument      , NULL, 'f'}
+    };
+    return (*opts = tpm2_options_new ("x:Q:l:f:p:q:o:c:", ARRAY_LEN(topts),
+        topts, on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.pcrList) {
+        fprintf (stderr, "No PCRs were chosen, use --pcrList\n");
+        return -1;
+    }
+    if (!ctx.keyPath) {
+        fprintf (stderr, "No key path provided, use --keyPath\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.qualifyingData) {
+        fprintf (stderr, "No qualifying data provided, use "\
+            "--qualifyingData\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "No signature provided, use --signature\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.pcrLog) {
+        fprintf (stderr, "No PCR event log provided, use --pcrLog\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.certificate) {
+        fprintf (stderr, "No Certificate provided, use --certificate\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.quoteInfo) {
+        fprintf (stderr, "No quoteInfo provided, use --quoteInfo\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!strcmp (ctx.quoteInfo, "-") + !strcmp (ctx.pcrLog, "-") +
+        !strcmp (ctx.signature, "-") + !strcmp (ctx.certificate, "-") > 1) {
+            fprintf (stderr, "Only one of --quoteInfo, --pcrLog, "\
+                "--signature and --certificate can print to standard "\
+                "output");
+            free (ctx.pcrList);
+        return -1;
+    }
+
+    /* Read qualifyingData file */
+    uint8_t *qualifyingData;
+    size_t qualifyingDataSize;
+    TSS2_RC r = open_read_and_close (ctx.qualifyingData, (void*)&qualifyingData,
+        &qualifyingDataSize);
+    if (r) {
+      free (ctx.pcrList);
+      return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *signature;
+    size_t signatureSize;
+    char *quoteInfo, *pcrLog = NULL, *certificate = NULL;
+    r = Fapi_Quote (fctx, ctx.pcrList, 1, ctx.keyPath,
+        NULL, qualifyingData, qualifyingDataSize, &quoteInfo,
+        &signature, &signatureSize, &pcrLog, &certificate);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Quote", r);
+        free (ctx.pcrList);
+        free (qualifyingData);
+        return 1;
+    }
+
+    free (ctx.pcrList);
+    free (qualifyingData);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
+    if (r){
+        LOG_PERR ("open_write_and_close quoteInfo", r);
+        Fapi_Free (quoteInfo);
+        if (pcrLog){
+            Fapi_Free (pcrLog);
+        }
+        Fapi_Free (signature);
+        return 1;
+    }
+
+    Fapi_Free (quoteInfo);
+
+    if (pcrLog){
+        r = open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog,
+            0);
+        if (r){
+            LOG_PERR ("open_write_and_close pcrLog", r);
+            Fapi_Free (pcrLog);
+            Fapi_Free (signature);
+            return 1;
+        }
+        Fapi_Free (pcrLog);
+    }
+
+    r = open_write_and_close (ctx.signature, ctx.overwrite, signature,
+        signatureSize);
+    if (r) {
+        LOG_PERR ("open_write_and_close signature", r);
+        Fapi_Free (signature);
+        return 1;
+    }
+    Fapi_Free (signature);
+
+    r = open_write_and_close (ctx.certificate, ctx.overwrite, certificate,
+        strlen(certificate));
+    if (r) {
+        LOG_PERR ("open_write_and_close certificate", r);
+        Fapi_Free (certificate);
+        return 1;
+    }
+    Fapi_Free (certificate);
+
+    return 0;
+}

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -1,0 +1,225 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    uint32_t   *pcrList;
+    char const *keyPath;
+    char const *qualifyingData;
+    char const *quoteInfo;
+    char const *pcrEventLog;
+    char const *signature;
+    char const *certificate;
+    bool        overwrite;
+} ctx;
+
+/**
+ * Split the comma separated input, parse each token as number,
+ * put the numbers in the array output.  Allocate memory for
+ * output to hold the numbers.  The last element of output is -1.
+ *
+ * On failure returns false and output is not allocated.
+ * On success the caller frees output.
+ */
+static inline bool extract_pcrs(char *input, uint32_t **output) {
+    size_t size = 1;
+    char *temp = input;
+    while ((temp = strchr (temp+1, ','))) size++;
+    *output = malloc (sizeof(uint32_t) * (size + 1));
+    if (!*output) {
+        fprintf (stderr, "malloc failed: %m\n");
+        return false;
+    }
+    (*output)[size] = -1;
+    char *x = strtok_r (input, ",", &temp);
+    if (!tpm2_util_string_to_uint32(x, output[0])) {
+        fprintf (stderr, "%s cannot be used as PCR\n", x);
+        free (*output);
+        return false;
+    }
+    size = 0;
+    while ((x = strtok_r (NULL, ",", &temp))) {
+      if (!tpm2_util_string_to_uint32(x, &(*output)[++size])) {
+            fprintf (stderr, "%s cannot be used as PCR\n", x);
+            free (*output);
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    (void)value;
+    switch (key) {
+    case 'L':
+        return extract_pcrs(value, &ctx.pcrList);
+    case 'd':
+        ctx.qualifyingData = value;
+        break;
+    case 'l':
+        ctx.pcrEventLog = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'k':
+        ctx.keyPath = value;
+        break;
+    case 'q':
+        ctx.quoteInfo = value;
+        break;
+    case 's':
+        ctx.signature = value;
+        break;
+    case 'c':
+        ctx.certificate = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"pcrList"       , required_argument, NULL, 'L'},
+        {"keyPath"        , required_argument, NULL, 'k'},
+        {"qualifyingData", required_argument, NULL, 'd'},
+        {"quoteInfo"     , required_argument, NULL, 'q'},
+        {"signature"      , required_argument, NULL, 's'},
+        {"pcrLog"        , required_argument, NULL, 'l'},
+        {"certificate"    , required_argument, NULL, 'c'},
+        {"force"          , no_argument      , NULL, 'f'}
+    };
+    return (*opts = tpm2_options_new ("L:d:l:f:k:q:s:c:", ARRAY_LEN(topts),
+        topts, on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.pcrList) {
+        fprintf (stderr, "No PCRs were chosen, use --pcrList\n");
+        return -1;
+    }
+    if (!ctx.keyPath) {
+        fprintf (stderr, "No key path provided, use --keyPath\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.qualifyingData) {
+        fprintf (stderr, "No qualifying data provided, use "\
+            "--qualifyingData\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "No signature provided, use --signature\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.pcrEventLog) {
+        fprintf (stderr, "No PCR event log provided, use --pcrLog\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.certificate) {
+        fprintf (stderr, "No Certificate provided, use --certificate=\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!ctx.quoteInfo) {
+        fprintf (stderr, "No quoteInfo provided, use --quoteInfo=\n");
+        free (ctx.pcrList);
+        return -1;
+    }
+    if (!strcmp (ctx.quoteInfo, "-") + !strcmp (ctx.pcrEventLog, "-") +
+        !strcmp (ctx.signature, "-") + !strcmp (ctx.certificate, "-") > 1) {
+            fprintf (stderr, "Only one of --quoteInfo, --pcrLog, "\
+                "--signature and --certificate can print to standard "\
+                "output");
+            free (ctx.pcrList);
+        return -1;
+    }
+
+    /* Read qualifyingData file */
+    uint8_t *qualifyingData;
+    size_t qualifyingDataSize;
+    TSS2_RC r = open_read_and_close (ctx.qualifyingData, (void*)&qualifyingData,
+        &qualifyingDataSize);
+    if (r) {
+      free (ctx.pcrList);
+      return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *signature;
+    size_t signatureSize;
+    char *quoteInfo, *pcrEventLog = NULL, *certificate = NULL;
+    r = Fapi_Quote (fctx, ctx.pcrList, 1, ctx.keyPath,
+        NULL, qualifyingData, qualifyingDataSize, &quoteInfo,
+        &signature, &signatureSize, &pcrEventLog, &certificate);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Quote", r);
+        free (ctx.pcrList);
+        free (qualifyingData);
+        return 1;
+    }
+
+    free (ctx.pcrList);
+    free (qualifyingData);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
+    if(r){
+        LOG_PERR ("open_write_and_close quoteInfo", r);
+        Fapi_Free (quoteInfo);
+        if(pcrEventLog){
+            Fapi_Free (pcrEventLog);
+        }
+        Fapi_Free (signature);
+        return 1;
+    }
+
+    Fapi_Free (quoteInfo);
+
+    if(pcrEventLog){
+        r = open_write_and_close (ctx.pcrEventLog, ctx.overwrite, pcrEventLog,
+            0);
+        if(r){
+            LOG_PERR ("open_write_and_close pcrEventLog", r);
+            Fapi_Free (pcrEventLog);
+            Fapi_Free (signature);
+            return 1;
+        }
+        Fapi_Free (pcrEventLog);
+    }
+
+    r = open_write_and_close (ctx.signature, ctx.overwrite, signature,
+        signatureSize);
+    if (r) {
+        LOG_PERR ("open_write_and_close signature", r);
+        Fapi_Free (signature);
+        return 1;
+    }
+    Fapi_Free (signature);
+
+    r = open_write_and_close (ctx.certificate, ctx.overwrite, certificate,
+        strlen(certificate));
+    if (r) {
+        LOG_PERR ("open_write_and_close certificate", r);
+        Fapi_Free (certificate);
+        return 1;
+    }
+    Fapi_Free (certificate);
+
+    return 0;
+}

--- a/tools/fapi/tss2_setappdata.c
+++ b/tools/fapi/tss2_setappdata.c
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    uint8_t const *data;
+    size_t  data_size;
+    char    const *path;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'a':
+        ctx.data_size = strlen(value);
+        ctx.data = (uint8_t*) value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"appData", required_argument, NULL, 'a'},
+        {"path", required_argument, NULL, 'p'},
+    };
+    return (*opts = tpm2_options_new ("a:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_SetAppData (fctx, ctx.path, ctx.data, ctx.data_size);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_SetAppData", r);
+        return 1;
+    }
+    return 0;
+}

--- a/tools/fapi/tss2_setappdata.c
+++ b/tools/fapi/tss2_setappdata.c
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    uint8_t const *data;
+    size_t  data_size;
+    char    const *path;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i':
+        ctx.data_size = strlen(value);
+        ctx.data = (uint8_t*) value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"appData", required_argument, NULL, 'i'},
+        {"path", required_argument, NULL, 'p'},
+    };
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_SetAppData (fctx, ctx.path, ctx.data, ctx.data_size);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_SetAppData", r);
+        return 1;
+    }
+    return 0;
+}

--- a/tools/fapi/tss2_setappdata.c
+++ b/tools/fapi/tss2_setappdata.c
@@ -20,7 +20,7 @@ static struct cxt {
 /* Parse commandline parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'a':
+    case 'i':
         ctx.data_size = strlen(value);
         ctx.data = (uint8_t*) value;
         break;
@@ -34,10 +34,10 @@ static bool on_option(char key, char *value) {
 /* Define possible commandline parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"appData", required_argument, NULL, 'a'},
+        {"appData", required_argument, NULL, 'i'},
         {"path", required_argument, NULL, 'p'},
     };
-    return (*opts = tpm2_options_new ("a:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -45,7 +45,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *x509cert;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'i':
+        ctx.x509cert = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path"    , required_argument, NULL, 'p'},
+        {"x509certData", required_argument, NULL, 'i'}
+    };
+    return (*opts = tpm2_options_new ("p:i", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path missing, use --path\n");
+        return -1;
+    }
+    if (!ctx.x509cert) {
+        fprintf (stderr, "x509certData missing, use --x509certData\n");
+        return -1;
+    }
+
+    /* Read x509 certificate from file */
+    char* x509certData;
+    size_t x509certSize;
+    TSS2_RC r = open_read_and_close (ctx.x509cert, (void**)&x509certData,
+        &x509certSize);
+    if (r){
+        LOG_PERR("open_read_and_close x509cert", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_SetCertificate (fctx, ctx.path, x509certData);
+    if (r != TSS2_RC_SUCCESS){
+        free (x509certData);
+        LOG_PERR("Fapi_SetCertificate", r);
+        return 1;
+    }
+    free (x509certData);
+    return 0;
+}

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *x509cert;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'x':
+        ctx.x509cert = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path"    , required_argument, NULL, 'p'},
+        {"x509certData", required_argument, NULL, 'x'}
+    };
+    return (*opts = tpm2_options_new ("p:x:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path missing, use --path=\n");
+        return -1;
+    }
+    if (!ctx.x509cert) {
+        fprintf (stderr, "x509certData missing, use --x509certData=\n");
+        return -1;
+    }
+
+    /* Read x509 certificate from file */
+    char* x509certData;
+    size_t x509certSize;
+    TSS2_RC r = open_read_and_close (ctx.x509cert, (void**)&x509certData,
+        &x509certSize);
+    if (r){
+        LOG_PERR("open_read_and_close x509cert", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_SetCertificate (fctx, ctx.path, x509certData);
+    if (r != TSS2_RC_SUCCESS){
+        free (x509certData);
+        LOG_PERR("Fapi_SetCertificate", r);
+        return 1;
+    }
+    free (x509certData);
+    return 0;
+}

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -19,7 +19,7 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.path = value;
         break;
-    case 'x':
+    case 'i':
         ctx.x509cert = value;
         break;
     }
@@ -30,9 +30,9 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"    , required_argument, NULL, 'p'},
-        {"x509certData", required_argument, NULL, 'x'}
+        {"x509certData", required_argument, NULL, 'i'}
     };
-    return (*opts = tpm2_options_new ("p:x:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:i", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -40,11 +40,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path missing, use --path=\n");
+        fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
     if (!ctx.x509cert) {
-        fprintf (stderr, "x509certData missing, use --x509certData=\n");
+        fprintf (stderr, "x509certData missing, use --x509certData\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_setdescription.c
+++ b/tools/fapi/tss2_setdescription.c
@@ -16,7 +16,7 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'd':
+    case 'i':
         if (value && strlen (value) > 1023) {
             fprintf (stderr, "The description can be at most 1023 octets\n");
             return false;
@@ -33,10 +33,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"description", required_argument, NULL, 'd'},
+        {"description", required_argument, NULL, 'i'},
         {"path"       , required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("d:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -44,11 +44,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
-        fprintf (stderr, "path is missing, use --path=\n");
+        fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
     if (!ctx.description) {
-        fprintf (stderr, "description is missing, use --description=\n");
+        fprintf (stderr, "description is missing, use --description\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_setdescription.c
+++ b/tools/fapi/tss2_setdescription.c
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *description;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'd':
+        if (value && strlen (value) > 1023) {
+            fprintf (stderr, "The description can be at most 1023 octets\n");
+            return false;
+        }
+        ctx.description = value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"description", required_argument, NULL, 'd'},
+        {"path"       , required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("d:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path=\n");
+        return -1;
+    }
+    if (!ctx.description) {
+        fprintf (stderr, "description is missing, use --description=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_SetDescription (fctx, ctx.path, ctx.description);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_SetDescription", r);
+        return 1;
+    }
+    return 0;
+}

--- a/tools/fapi/tss2_setdescription.c
+++ b/tools/fapi/tss2_setdescription.c
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *description;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'i':
+        if (value && strlen (value) > 1023) {
+            fprintf (stderr, "The description can be at most 1023 octets\n");
+            return false;
+        }
+        ctx.description = value;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"description", required_argument, NULL, 'i'},
+        {"path"       , required_argument, NULL, 'p'}
+    };
+    return (*opts = tpm2_options_new ("i:p:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path\n");
+        return -1;
+    }
+    if (!ctx.description) {
+        fprintf (stderr, "description is missing, use --description\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_SetDescription (fctx, ctx.path, ctx.description);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_SetDescription", r);
+        return 1;
+    }
+    return 0;
+}

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *digest;
+    char const *signature;
+    char const *publicKey;
+    char const *certificate;
+    bool        overwrite;
+    char const *padding;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'c':
+        ctx.certificate = value;
+        break;
+    case 'd':
+        ctx.digest = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'k':
+        ctx.keyPath = value;
+        break;
+    case 'p':
+        ctx.publicKey = value;
+        break;
+    case 's':
+        ctx.signature = value;
+        break;
+    case 'P':
+        ctx.padding = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'k'},
+        {"padding",     required_argument, NULL, 'P'},
+        {"digest",      required_argument, NULL, 'd'},
+        {"signature",   required_argument, NULL, 's'},
+        {"publicKey",   required_argument, NULL, 'p'},
+        {"force",       no_argument      , NULL, 'f'},
+        {"certificate", required_argument, NULL, 'c'},
+
+    };
+    return (*opts = tpm2_options_new ("c:d:f:k:p:s:P:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+
+    /* Check availability of required parameters */
+    if (!ctx.digest) {
+        fprintf (stderr, "digest missing, use --digest=\n");
+        return -1;
+    }
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path missing, use --keyPath=\n");
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "signature missing, use --signature=\n");
+        return -1;
+    }
+    if(ctx.publicKey && ctx.certificate){
+        if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) +
+            !strcmp("-", ctx.certificate ? ctx.certificate : "") > 1) {
+            fprintf (stderr, "At most one of --certificate, --publicKey and "\
+                "--signature can be '-' (standard output)\n");
+            return -1;
+        }
+    }
+    if(ctx.publicKey && !ctx.certificate){
+        if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) > 1) {
+            fprintf (stderr, "At most one of --publicKey and --signature can "\
+                "be '-' (standard output)\n");
+            return -1;
+        }
+    }
+    if(ctx.certificate && !ctx.publicKey){
+        if (!strcmp ("-", ctx.signature) + !strcmp("-",
+            ctx.certificate ? ctx.certificate : "") > 1) {
+            fprintf (stderr, "At most one of --certificate and --signature can"\
+            " be '-' (standard output)\n");
+            return -1;
+        }
+    }
+
+    /* Read data needed to create signature */
+    uint8_t *digest, *signature;
+    size_t digestSize, signatureSize;
+    char *publicKey, *certificate = NULL;
+    TSS2_RC r = open_read_and_close (ctx.digest, (void**)&digest, &digestSize);
+    if (r){
+        LOG_PERR ("open_read_and_close digest", r);
+        return 1;
+    }
+
+    if(ctx.certificate){
+        r = open_read_and_close (ctx.certificate, (void**)&certificate,
+            &digestSize);
+        if (r){
+            LOG_PERR ("open_read_and_close certificate", r);
+            return 1;
+        }
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_Sign (fctx, ctx.keyPath, ctx.padding, digest,
+        digestSize, &signature, &signatureSize, &publicKey, ctx.certificate ?
+        &certificate : NULL);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Sign", r);
+        free (digest);
+        return 1;
+    }
+    free (digest);
+
+    /* Write returned data to file(s) */
+    if (ctx.certificate) {
+        if(certificate && strlen(certificate)){
+            r = open_write_and_close (ctx.certificate, ctx.overwrite,
+                certificate, strlen(certificate));
+            if (r) {
+                LOG_PERR ("open_write_and_close certificate", r);
+                free (certificate);
+                Fapi_Free (signature);
+                Fapi_Free (publicKey);
+                return 1;
+            }
+        }
+    }
+    r = open_write_and_close (ctx.signature, ctx.overwrite, signature,
+        signatureSize);
+    if (r) {
+        LOG_PERR ("open_write_and_close certificate signature", r);
+        Fapi_Free (signature);
+        Fapi_Free (publicKey);
+        return 1;
+    }
+
+    r = open_write_and_close (ctx.publicKey, ctx.overwrite, publicKey,
+            strlen(publicKey));
+    if (r) {
+        LOG_PERR ("open_write_and_close certificate publicKey", r);
+        Fapi_Free (signature);
+        Fapi_Free (publicKey);
+        return 1;
+    }
+
+    Fapi_Free (signature);
+    Fapi_Free (publicKey);
+
+    return 0;
+}

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *digest;
+    char const *signature;
+    char const *publicKey;
+    char const *certificate;
+    bool        overwrite;
+    char const *padding;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'c':
+        ctx.certificate = value;
+        break;
+    case 'd':
+        ctx.digest = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'k':
+        ctx.publicKey = value;
+        break;
+    case 'o':
+        ctx.signature = value;
+        break;
+    case 's':
+        ctx.padding = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"padding",     required_argument, NULL, 's'},
+        {"digest",      required_argument, NULL, 'd'},
+        {"signature",   required_argument, NULL, 'o'},
+        {"publicKey",   required_argument, NULL, 'k'},
+        {"force",       no_argument      , NULL, 'f'},
+        {"certificate", required_argument, NULL, 'c'},
+
+    };
+    return (*opts = tpm2_options_new ("c:d:f:p:k:o:s:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+
+    /* Check availability of required parameters */
+    if (!ctx.digest) {
+        fprintf (stderr, "digest missing, use --digest\n");
+        return -1;
+    }
+    if (!ctx.keyPath) {
+        fprintf (stderr, "key path missing, use --keyPath\n");
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "signature missing, use --signature\n");
+        return -1;
+    }
+    if (ctx.publicKey && ctx.certificate){
+        if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) +
+            !strcmp("-", ctx.certificate ? ctx.certificate : "") > 1) {
+            fprintf (stderr, "At most one of --certificate, --publicKey and "\
+                "--signature can be '-' (standard output)\n");
+            return -1;
+        }
+    }
+    if (ctx.publicKey && !ctx.certificate){
+        if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) > 1) {
+            fprintf (stderr, "At most one of --publicKey and --signature can "\
+                "be '-' (standard output)\n");
+            return -1;
+        }
+    }
+    if (ctx.certificate && !ctx.publicKey){
+        if (!strcmp ("-", ctx.signature) + !strcmp("-",
+            ctx.certificate ? ctx.certificate : "") > 1) {
+            fprintf (stderr, "At most one of --certificate and --signature can"\
+            " be '-' (standard output)\n");
+            return -1;
+        }
+    }
+
+    /* Read data needed to create signature */
+    uint8_t *digest, *signature;
+    size_t digestSize, signatureSize;
+    char *publicKey, *certificate = NULL;
+    TSS2_RC r = open_read_and_close (ctx.digest, (void**)&digest, &digestSize);
+    if (r){
+        LOG_PERR ("open_read_and_close digest", r);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_Sign (fctx, ctx.keyPath, ctx.padding, digest,
+        digestSize, &signature, &signatureSize, &publicKey, ctx.certificate ?
+        &certificate : NULL);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_Sign", r);
+        free (digest);
+        return 1;
+    }
+    free (digest);
+
+    /* Write returned data to file(s) */
+    if (ctx.certificate) {
+        if (certificate && strlen(certificate)){
+            r = open_write_and_close (ctx.certificate, ctx.overwrite,
+                certificate, strlen(certificate));
+            if (r) {
+                LOG_PERR ("open_write_and_close certificate", r);
+                free (certificate);
+                Fapi_Free (signature);
+                Fapi_Free (publicKey);
+                return 1;
+            }
+        }
+    }
+    r = open_write_and_close (ctx.signature, ctx.overwrite, signature,
+        signatureSize);
+    if (r) {
+        LOG_PERR ("open_write_and_close certificate signature", r);
+        Fapi_Free (signature);
+        Fapi_Free (publicKey);
+        return 1;
+    }
+
+    r = open_write_and_close (ctx.publicKey, ctx.overwrite, publicKey,
+            strlen(publicKey));
+    if (r) {
+        LOG_PERR ("open_write_and_close certificate publicKey", r);
+        Fapi_Free (signature);
+        Fapi_Free (publicKey);
+        return 1;
+    }
+
+    Fapi_Free (signature);
+    Fapi_Free (publicKey);
+
+    return 0;
+}

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -81,7 +81,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "signature missing, use --signature=\n");
         return -1;
     }
-    if(ctx.publicKey && ctx.certificate){
+    if (ctx.publicKey && ctx.certificate){
         if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) +
             !strcmp("-", ctx.certificate ? ctx.certificate : "") > 1) {
             fprintf (stderr, "At most one of --certificate, --publicKey and "\
@@ -89,14 +89,14 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             return -1;
         }
     }
-    if(ctx.publicKey && !ctx.certificate){
+    if (ctx.publicKey && !ctx.certificate){
         if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) > 1) {
             fprintf (stderr, "At most one of --publicKey and --signature can "\
                 "be '-' (standard output)\n");
             return -1;
         }
     }
-    if(ctx.certificate && !ctx.publicKey){
+    if (ctx.certificate && !ctx.publicKey){
         if (!strcmp ("-", ctx.signature) + !strcmp("-",
             ctx.certificate ? ctx.certificate : "") > 1) {
             fprintf (stderr, "At most one of --certificate and --signature can"\
@@ -115,7 +115,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
 
-    if(ctx.certificate){
+    if (ctx.certificate){
         r = open_read_and_close (ctx.certificate, (void**)&certificate,
             &digestSize);
         if (r){
@@ -137,7 +137,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Write returned data to file(s) */
     if (ctx.certificate) {
-        if(certificate && strlen(certificate)){
+        if (certificate && strlen(certificate)){
             r = open_write_and_close (ctx.certificate, ctx.overwrite,
                 certificate, strlen(certificate));
             if (r) {

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -33,16 +33,16 @@ static bool on_option(char key, char *value) {
     case 'f':
         ctx.overwrite = true;
         break;
-    case 'k':
+    case 'p':
         ctx.keyPath = value;
         break;
-    case 'p':
+    case 'k':
         ctx.publicKey = value;
         break;
-    case 's':
+    case 'o':
         ctx.signature = value;
         break;
-    case 'P':
+    case 's':
         ctx.padding = value;
         break;
     }
@@ -52,16 +52,16 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
-        {"padding",     required_argument, NULL, 'P'},
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"padding",     required_argument, NULL, 's'},
         {"digest",      required_argument, NULL, 'd'},
-        {"signature",   required_argument, NULL, 's'},
-        {"publicKey",   required_argument, NULL, 'p'},
+        {"signature",   required_argument, NULL, 'o'},
+        {"publicKey",   required_argument, NULL, 'k'},
         {"force",       no_argument      , NULL, 'f'},
         {"certificate", required_argument, NULL, 'c'},
 
     };
-    return (*opts = tpm2_options_new ("c:d:f:k:p:s:P:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("c:d:f:p:k:o:s:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -70,15 +70,15 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Check availability of required parameters */
     if (!ctx.digest) {
-        fprintf (stderr, "digest missing, use --digest=\n");
+        fprintf (stderr, "digest missing, use --digest\n");
         return -1;
     }
     if (!ctx.keyPath) {
-        fprintf (stderr, "key path missing, use --keyPath=\n");
+        fprintf (stderr, "key path missing, use --keyPath\n");
         return -1;
     }
     if (!ctx.signature) {
-        fprintf (stderr, "signature missing, use --signature=\n");
+        fprintf (stderr, "signature missing, use --signature\n");
         return -1;
     }
     if (ctx.publicKey && ctx.certificate){
@@ -113,15 +113,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (r){
         LOG_PERR ("open_read_and_close digest", r);
         return 1;
-    }
-
-    if (ctx.certificate){
-        r = open_read_and_close (ctx.certificate, (void**)&certificate,
-            &digestSize);
-        if (r){
-            LOG_PERR ("open_read_and_close certificate", r);
-            return 1;
-        }
     }
 
     /* Execute FAPI command with passed arguments */

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -1,0 +1,463 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <fcntl.h>
+#include <libgen.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <termios.h>
+#include <unistd.h>
+#include <tss2/tss2_rc.h>
+#include <sys/wait.h>
+#include <stdarg.h>
+#include <errno.h>
+
+#include "tools/fapi/tss2_template.h"
+#include "lib/config.h"
+
+static struct termios old;
+
+/* When the program is interrupted during callbacks,
+ * restore the old termios state (with ICANON and ECHO) */
+static void signal_termio_restore(__attribute__((unused)) int signumber) {
+    tcsetattr (STDIN_FILENO, TCSANOW, &old);
+}
+
+/* adapted from lib/tpm2_options.c for tss2 */
+static bool execute_man(char *prog_name, bool show_errors) {
+    pid_t pid;
+    int status;
+
+    if ((pid = fork()) < 0) {
+        LOG_ERR("Could not fork process to execute man, error: %s",
+                strerror(errno));
+        return false;
+    }
+
+    if (pid == 0) {
+
+        if (!show_errors) {
+            /* redirect manpager errors to stderr */
+            int fd = open("/dev/null", O_WRONLY);
+            if (fd < 0) {
+                LOG_ERR("Could not open /dev/null");
+                return false;
+            }
+            dup2(fd, 2);
+            close(fd);
+        }
+
+        char *manpage = basename(prog_name);
+        execlp("man", "man", manpage, NULL);
+    } else {
+        if ((pid = waitpid(pid, &status, 0)) == -1) {
+            LOG_ERR("Waiting for child process that executes man failed, error:"
+                    " %s", strerror(errno));
+            return false;
+        }
+
+        return WEXITSTATUS(status) == 0;
+    }
+
+    return true;
+}
+
+/* adapted from lib/tpm2_options.c for tss2 */
+static tpm2_option_code tss2_handle_options (
+    int            argc,
+    char         **argv,
+    tpm2_options **tool_opts,
+    FAPI_CONTEXT  *fctx) {
+    tpm2_option_code rc = tpm2_option_code_err;
+    bool show_help = false, manpager = true, explicit_manpager = false;
+    struct option long_options [] = {
+       {"help"   , optional_argument, NULL, 'h'},
+       {"version", no_argument, NULL, 'v'}
+    };
+    tpm2_options *opts = tpm2_options_new("h::v",
+            ARRAY_LEN(long_options), long_options, NULL, NULL, 0);
+    if (!opts) {
+        return tpm2_option_code_err;
+    }
+    /* Get the options from the tool */
+    tpm2_option_handler on_opt = (*tool_opts)->callbacks.on_opt;
+    tpm2_arg_handler on_arg = (*tool_opts)->callbacks.on_arg;
+    if (!tpm2_options_cat (tool_opts, opts))
+        goto out;
+    (*tool_opts)->callbacks.on_opt = on_opt;
+    (*tool_opts)->callbacks.on_arg = on_arg;
+    /* Parse the options, calling the tool callback if unknown */
+    int c;
+    while ((c = getopt_long (argc, argv, (*tool_opts)->short_opts,
+        (*tool_opts)->long_opts, NULL)) != -1) {
+        switch (c) {
+        case 'h':
+            show_help = true;
+            if (argv[optind]) {
+                if (!strcmp(argv[optind], "man")) {
+                    manpager = true;
+                    explicit_manpager = true;
+                    optind++;
+                } else if (!strcmp(argv[optind], "no-man")) {
+                    manpager = false;
+                    optind++;
+                } else {
+                    show_help=false;
+                    fprintf (stderr, "Unknown help argument, got: \"%s\"\n",
+                        argv[optind]);
+                }
+            }
+            goto out;
+            break;
+        case 'v': {
+            char *prog_name = strdup (argv[0]);
+            if (!prog_name) {
+                fprintf (stderr, "Not enough memory\n");
+                goto out;
+            }
+            char *fapi_version;
+            TSS2_RC ret = Fapi_GetInfo(fctx, &fapi_version);
+            if (ret != TSS2_RC_SUCCESS) {
+                fprintf (stderr, "Fapi_GetInfo returned %u\n", ret);
+                goto out;
+            }
+            char* target = strndup(fapi_version, 50); // TODO: Extract correct version
+            /* N.B. the returned version is UTF-8 and printing it correct
+             * depends on the locale */
+            Fapi_Free(fapi_version);
+            printf ("%s from " PACKAGE " version " VERSION " using at run time "
+                    "FAPI library version %s.\nCopyright (C) 2019 Fraunhofer SI"
+                    "T.\nLicense BSD-3-Clause.\nMy homepage is https://github.com/tpm2"
+                    "-software/tpm2-tools .  The homepage of the FAPI library i"
+                    "s https://github.com/tpm2-software/tpm2-tss .\n",
+                    basename (prog_name), target /*fapi_version*/);
+            free(prog_name);
+            free(target);
+            }
+            rc = tpm2_option_code_stop;
+            goto out;
+        case '?':
+            goto out;
+        default:
+            if (!*tool_opts || !(*tool_opts)->callbacks.on_opt) {
+                fprintf (stderr, "Unknown option found: %c\n", c);
+                goto out;
+            }
+            if (!(*tool_opts)->callbacks.on_opt(c, optarg))
+                goto out;
+        }
+    }
+
+    char **tool_args = &argv[optind];
+    int tool_argc = argc - optind;
+
+    /* have args and no handler, error condition */
+    if (tool_argc && (!*tool_opts || !(*tool_opts)->callbacks.on_arg)) {
+        char *prog_name = strdup (argv[0]);
+        if (!prog_name) {
+            fprintf (stderr, "Not enough memory\n");
+            goto out;
+        }
+        fprintf (stderr, "Got arguments but %s takes no arguments\n",
+            basename (prog_name));
+        free (prog_name);
+        goto out;
+    } else if (tool_argc && (*tool_opts)->callbacks.on_arg
+        && !(*tool_opts)->callbacks.on_arg(tool_argc, tool_args)) {
+        goto out;
+    }
+    rc = tpm2_option_code_continue;
+out:
+    /*
+     * If help output is selected via -h or indicated by an error that help
+     * output is desirable, show it.
+     *
+     * However, 3 conditions are possible:
+     * 1. Try manpager and success -- done, no need to show short help output.
+     * 2. Try manpager and failure -- show short help output.
+     * 3. Do not use manpager -- show short help output.
+     *
+     */
+    if (show_help) {
+        if (!manpager || !execute_man (argv[0], explicit_manpager)) {
+            tpm2_print_usage (argv[0], *tool_opts);
+        }
+        rc = tpm2_option_code_stop;
+    }
+    tpm2_options_free (opts);
+
+    return rc;
+}
+
+TSS2_RC auth_callback(
+    __attribute__((unused)) FAPI_CONTEXT *fapi_context,
+    char const                   *description,
+    char                        **auth,
+    __attribute__((unused)) void *userdata)
+{
+    struct termios new;
+    tcgetattr (STDIN_FILENO, &old);
+    new = old;
+    new.c_lflag &= ~(ICANON | ECHO);
+    printf ("Authorize object %s: ", description);
+    tcsetattr (STDIN_FILENO, TCSANOW, &new);
+    *auth = NULL; /* because the caller does not set this to NULL, and because
+                     getline allocates space for *auth, if it was NULL */
+    size_t input_size = 0;
+    struct sigaction signal_action;
+    memset (&signal_action, 0, sizeof signal_action);
+    signal_action.sa_handler = signal_termio_restore;
+    sigaction (SIGTERM, &signal_action, NULL);
+    sigaction (SIGINT, &signal_action, NULL);
+    ssize_t getline_ret = getline (auth, &input_size, stdin);
+    /* It is intentional, that auth can contain null bytes, and from
+     * FAPI’s perspective these terminate the password. */
+    tcsetattr (STDIN_FILENO, TCSANOW, &old);
+    signal_action.sa_handler = SIG_DFL;
+    sigaction (SIGTERM, &signal_action, NULL);
+    sigaction (SIGINT, &signal_action, NULL);
+    printf ("\n");
+    if (getline_ret == -1) {
+        fprintf (stderr, "getline() failed: %m\n");
+        free (*auth);
+        *auth = NULL;
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+    (*auth)[getline_ret - 1] = '\0';
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC branch_callback(
+    __attribute__((unused)) FAPI_CONTEXT        *fapi_context,
+    char                    const  *description,
+    char                    const **branchNames,
+    size_t                          numBranches,
+    size_t                         *selectedBranch,
+    __attribute__((unused)) void   *userData)
+{
+    printf ("Select a branch for %s\n", description);
+    for (size_t i = 0; i < numBranches; i++) {
+        printf ("%4zu %s\n", i + 1, branchNames[i]);
+    }
+
+    while (1) {
+        printf ("Your choice: ");
+        if (scanf ("%zu", selectedBranch) != EOF) {
+            while (getchar () != '\n'); /* Consume all remainign input */
+            if (*selectedBranch > numBranches || *selectedBranch < 1) {
+                fprintf (stderr, "The entered integer must be positive and "\
+                    "less than %zu.\n", numBranches + 1);
+            } else {
+                numBranches--;
+                return TSS2_RC_SUCCESS;
+            }
+        } else {
+            fprintf (stderr, "No number received, but EOF.\n");
+            return TSS2_RC_SUCCESS;
+        }
+    }
+}
+
+static FAPI_CONTEXT* ctx_init(char const * uri) {
+    FAPI_CONTEXT* ret;
+    const unsigned int rval = Fapi_Initialize(&ret, uri);
+    if (rval != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_Initialize", rval);
+        return NULL;
+    }
+    return ret;
+}
+
+/*
+ * This program is a template for TPM2 tools that use the FAPI. It does
+ * nothing more than parsing command line options that allow the caller to
+ * specify which FAPI function to call.
+ */
+int main(int argc, char *argv[]) {
+    tpm2_options *tool_opts = NULL;
+    if (!tss2_tool_onstart (&tool_opts)) {
+        fprintf (stderr,"error retrieving tool options\n");
+        return 1;
+    }
+    int ret = 1;
+    char *password = NULL;
+    FAPI_CONTEXT *fctx = ctx_init (NULL);
+    if (!fctx)
+        goto free_opts;
+
+    TSS2_RC r = Fapi_SetAuthCB (fctx, auth_callback, &password);
+    if (r != TSS2_RC_SUCCESS) {
+        fprintf (stderr, "Fapi_SetAuthCB returned %u\n", r);
+        Fapi_Finalize (&fctx);
+        goto free_opts;
+    }
+    r = Fapi_SetBranchCB (fctx, branch_callback, NULL);
+    if (r != TSS2_RC_SUCCESS) {
+        fprintf (stderr, "Fapi_SetBranchCB returned %u\n", r);
+        Fapi_Finalize (&fctx);
+        goto free_opts;
+    }
+
+    tpm2_option_code rc = tss2_handle_options (argc, argv, &tool_opts, fctx);
+
+    if (rc != tpm2_option_code_continue) {
+        ret = rc == tpm2_option_code_err ? 1 : 0;
+        Fapi_Finalize (&fctx);
+        goto free_opts;
+    }
+
+    /*
+     * Call the specific tool, all tools implement this function instead of
+     * 'main'.
+     * rc 1 = failure
+     * rc 0 = success
+     * rc -1 = show usage
+     */
+    ret = tss2_tool_onrun(fctx);
+    if (ret < 0) {
+        tpm2_print_usage(argv[0], tool_opts);
+        ret = 1;
+    }
+
+    /*
+     * Cleanup contexts & memory allocated for the modified argument vector
+     * passed to execute_tool.
+     */
+    Fapi_Finalize (&fctx);
+free_opts:
+    if (tool_opts)
+        tpm2_options_free (tool_opts);
+    free (password);
+    exit(ret);
+}
+
+int open_write_and_close(const char* path, bool overwrite, const void *output,
+    size_t output_len) {
+    size_t length = output_len ? output_len : strlen (output);
+    if (!path || !strcmp(path, "-")) {
+        if (-1 == write (STDOUT_FILENO, output, length)) {
+            fprintf (stderr, "write(2) to stdout failed: %m\n");
+            return 1;
+        }
+        putchar ('\n');
+        return 0;
+    }
+    if (!overwrite) {
+        struct stat stat_;
+        if (!stat (path, &stat_)) {
+            fprintf (stderr, "File %s already exists, use --force to "\
+                "overwrite it\n", path);
+            return 1;
+        }
+    }
+    int fileno = open (path, O_CREAT | O_WRONLY | O_TRUNC, S_IWUSR | S_IRUSR);
+    if (fileno == -1) {
+        fprintf (stderr, "open(2) %s failed: %m\n", path);
+        return 1;
+    }
+
+    ssize_t bytes_written = write (fileno, output, length);
+    if (bytes_written == -1) {
+        fprintf (stderr, "write(2) %s failed: %m\n", path);
+        return 1;
+    }
+    if (bytes_written - length) {
+        fprintf (stderr, "write(2) could not write the whole file, deleting "\
+            "%s\n", path);
+        unlink (path);
+        close (fileno);
+        return 1;
+    }
+    if (close (fileno)) {
+        fprintf (stderr, "close(2) %s failed: %m\n", path);
+        return 1;
+    }
+    return 0;
+}
+
+int open_read_and_close (const char *path, void **input, size_t *size) {
+    if (!path || !strcmp(path, "-")) {
+        size_t data_consumed = 0, buffer_size = 1024, data_read;
+        *input = malloc (buffer_size + 1);
+        if (!*input) {
+            fprintf (stderr, "malloc(2) failed: %m\n");
+            return 1;
+        }
+        while ((data_read = read (STDIN_FILENO, *input + data_consumed, 1024))){
+            data_consumed += data_read;
+            if (data_read < 1024) /* EOF reached */
+                break;
+            buffer_size += 1024;
+            *input = realloc (*input, buffer_size + 1);
+            if (!*input) {
+                fprintf (stderr, "realloc(3) failed: %m\n");
+                return 1;
+            }
+        }
+        if (size)
+            *size = data_consumed;
+        ((char*)(*input))[data_consumed] = 0;
+        return 0;
+    }
+    int fileno = open (path, O_RDONLY);
+    if (fileno == -1) {
+        fprintf (stderr, "Opening %s failed: %m\n", path);
+        return 1;
+    }
+
+    struct stat stat_;
+    fstat (fileno, &stat_);
+    if (size)
+        *size = stat_.st_size;
+    *input = malloc (stat_.st_size + 1);
+    if (!*input) {
+        fprintf (stderr, "malloc(2) failed: %m\n");
+        return 1;
+    }
+    if (-1 == read (fileno, *input, stat_.st_size)) {
+        fprintf (stderr, "read(2) %s failed with: %m\n", path);
+        free (*input);
+        return 1;
+    }
+    ((char*)(*input))[stat_.st_size] = '\0';
+    if (close (fileno)) {
+        fprintf (stderr, "Error close(2) %s: %m\n", path);
+        free (*input);
+        return 1;
+    }
+    return 0;
+}
+
+char* ask_for_password() {
+    char *pw1, *pw2;
+    if (auth_callback (NULL, "Password", &pw1, NULL))
+        return NULL;
+
+    if (auth_callback (NULL, "Retype password", &pw2, NULL)) {
+        free (pw1);
+        return NULL;
+    }
+    if (strcmp (pw1, pw2)) {
+        fprintf (stderr, "Passwords do not match.\n");
+        free (pw1);
+        free (pw2);
+        return NULL;
+    }
+    free (pw1);
+    return pw2;
+}
+
+void LOG_PERR(const char *func, TSS2_RC rc) {
+    fprintf (stderr, "%s(0x%X) - %s\n", func, rc, Tss2_RC_Decode(rc));
+}
+
+void LOG_ERR(const char *format, ...) {
+   va_list arg;
+   va_start (arg, format);
+   vfprintf (stderr, format, arg);
+   va_end (arg);
+}

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -1,0 +1,463 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <fcntl.h>
+#include <libgen.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <termios.h>
+#include <unistd.h>
+#include <tss2/tss2_rc.h>
+#include <sys/wait.h>
+#include <stdarg.h>
+#include <errno.h>
+
+#include "tools/fapi/tss2_template.h"
+#include "lib/config.h"
+
+static struct termios old;
+
+/* When the program is interrupted during callbacks,
+ * restore the old termios state (with ICANON and ECHO) */
+static void signal_termio_restore(__attribute__((unused)) int signumber) {
+    tcsetattr (STDIN_FILENO, TCSANOW, &old);
+}
+
+/* adapted from lib/tpm2_options.c for tss2 */
+static bool execute_man(char *prog_name, bool show_errors) {
+    pid_t pid;
+    int status;
+
+    if ((pid = fork()) < 0) {
+        LOG_ERR("Could not fork process to execute man, error: %s",
+                strerror(errno));
+        return false;
+    }
+
+    if (pid == 0) {
+
+        if (!show_errors) {
+            /* redirect manpager errors to stderr */
+            int fd = open("/dev/null", O_WRONLY);
+            if (fd < 0) {
+                LOG_ERR("Could not open /dev/null");
+                return false;
+            }
+            dup2(fd, 2);
+            close(fd);
+        }
+
+        char *manpage = basename(prog_name);
+        execlp("man", "man", manpage, NULL);
+    } else {
+        if ((pid = waitpid(pid, &status, 0)) == -1) {
+            LOG_ERR("Waiting for child process that executes man failed, error:"
+                    " %s", strerror(errno));
+            return false;
+        }
+
+        return WEXITSTATUS(status) == 0;
+    }
+
+    return true;
+}
+
+/* adapted from lib/tpm2_options.c for tss2 */
+static tpm2_option_code tss2_handle_options (
+    int            argc,
+    char         **argv,
+    tpm2_options **tool_opts,
+    FAPI_CONTEXT  *fctx) {
+    tpm2_option_code rc = tpm2_option_code_err;
+    bool show_help = false, manpager = true, explicit_manpager = false;
+    struct option long_options [] = {
+       {"help"   , optional_argument, NULL, 'h'},
+       {"version", no_argument, NULL, 'v'}
+    };
+    tpm2_options *opts = tpm2_options_new("h::v",
+            ARRAY_LEN(long_options), long_options, NULL, NULL, 0);
+    if (!opts) {
+        return tpm2_option_code_err;
+    }
+    /* Get the options from the tool */
+    tpm2_option_handler on_opt = (*tool_opts)->callbacks.on_opt;
+    tpm2_arg_handler on_arg = (*tool_opts)->callbacks.on_arg;
+    if (!tpm2_options_cat (tool_opts, opts))
+        goto out;
+    (*tool_opts)->callbacks.on_opt = on_opt;
+    (*tool_opts)->callbacks.on_arg = on_arg;
+    /* Parse the options, calling the tool callback if unknown */
+    int c;
+    while ((c = getopt_long (argc, argv, (*tool_opts)->short_opts,
+        (*tool_opts)->long_opts, NULL)) != -1) {
+        switch (c) {
+        case 'h':
+            show_help = true;
+            if (argv[optind]) {
+                if (!strcmp(argv[optind], "man")) {
+                    manpager = true;
+                    explicit_manpager = true;
+                    optind++;
+                } else if (!strcmp(argv[optind], "no-man")) {
+                    manpager = false;
+                    optind++;
+                } else {
+                    show_help=false;
+                    fprintf (stderr, "Unknown help argument, got: \"%s\"\n",
+                        argv[optind]);
+                }
+            }
+            goto out;
+            break;
+        case 'v': {
+            char *prog_name = strdup (argv[0]);
+            if (!prog_name) {
+                fprintf (stderr, "Not enough memory\n");
+                goto out;
+            }
+            char *fapi_version;
+            TSS2_RC ret = Fapi_GetInfo(fctx, &fapi_version);
+            if (ret != TSS2_RC_SUCCESS) {
+                fprintf (stderr, "Fapi_GetInfo returned %u\n", ret);
+                goto out;
+            }
+            char* target = strndup(fapi_version, 50); // TODO: Extract correct version
+            /* N.B. the returned version is UTF-8 and printing it correct
+             * depends on the locale */
+            Fapi_Free(fapi_version);
+            printf ("%s from " PACKAGE " version " VERSION " using at run time "
+                    "FAPI library version %s.\nCopyright (C) 2019 Fraunhofer SI"
+                    "T.\nLicense BSD-3-Clause.\nMy homepage is https://github.com/tpm2"
+                    "-software/tpm2-tools .  The homepage of the FAPI library i"
+                    "s https://github.com/tpm2-software/tpm2-tss .\n",
+                    basename (prog_name), target /*fapi_version*/);
+            free(prog_name);
+            free(target);
+            }
+            rc = tpm2_option_code_stop;
+            goto out;
+        case '?':
+            goto out;
+        default:
+            if (!*tool_opts || !(*tool_opts)->callbacks.on_opt) {
+                fprintf (stderr, "Unknown option found: %c\n", c);
+                goto out;
+            }
+            if (!(*tool_opts)->callbacks.on_opt(c, optarg))
+                goto out;
+        }
+    }
+
+    char **tool_args = &argv[optind];
+    int tool_argc = argc - optind;
+
+    /* have args and no handler, error condition */
+    if (tool_argc && (!*tool_opts || !(*tool_opts)->callbacks.on_arg)) {
+        char *prog_name = strdup (argv[0]);
+        if (!prog_name) {
+            fprintf (stderr, "Not enough memory\n");
+            goto out;
+        }
+        fprintf (stderr, "Got arguments but %s takes no arguments\n",
+            basename (prog_name));
+        free (prog_name);
+        goto out;
+    } else if (tool_argc && (*tool_opts)->callbacks.on_arg
+        && !(*tool_opts)->callbacks.on_arg(tool_argc, tool_args)) {
+        goto out;
+    }
+    rc = tpm2_option_code_continue;
+out:
+    /*
+     * If help output is selected via -h or indicated by an error that help
+     * output is desirable, show it.
+     *
+     * However, 3 conditions are possible:
+     * 1. Try manpager and success -- done, no need to show short help output.
+     * 2. Try manpager and failure -- show short help output.
+     * 3. Do not use manpager -- show short help output.
+     *
+     */
+    if (show_help) {
+        if (!manpager || !execute_man (argv[0], explicit_manpager)) {
+            tpm2_print_usage (argv[0], *tool_opts);
+        }
+        rc = tpm2_option_code_stop;
+    }
+    tpm2_options_free (opts);
+
+    return rc;
+}
+
+TSS2_RC auth_callback(
+    __attribute__((unused)) FAPI_CONTEXT *fapi_context,
+    char const                   *description,
+    char                        **auth,
+    __attribute__((unused)) void *userdata)
+{
+    struct termios new;
+    tcgetattr (STDIN_FILENO, &old);
+    new = old;
+    new.c_lflag &= ~(ICANON | ECHO);
+    printf ("Authorize object %s: ", description);
+    tcsetattr (STDIN_FILENO, TCSANOW, &new);
+    *auth = NULL; /* because the caller does not set this to NULL, and because
+                     getline allocates space for *auth, if it was NULL */
+    size_t input_size = 0;
+    struct sigaction signal_action;
+    memset (&signal_action, 0, sizeof signal_action);
+    signal_action.sa_handler = signal_termio_restore;
+    sigaction (SIGTERM, &signal_action, NULL);
+    sigaction (SIGINT, &signal_action, NULL);
+    ssize_t getline_ret = getline (auth, &input_size, stdin);
+    /* It is intentional, that auth can contain null bytes, and from
+     * FAPI’s perspective these terminate the password. */
+    tcsetattr (STDIN_FILENO, TCSANOW, &old);
+    signal_action.sa_handler = SIG_DFL;
+    sigaction (SIGTERM, &signal_action, NULL);
+    sigaction (SIGINT, &signal_action, NULL);
+    printf ("\n");
+    if (getline_ret == -1) {
+        fprintf (stderr, "getline() failed: %m\n");
+        free (*auth);
+        *auth = NULL;
+        return TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+    (*auth)[getline_ret - 1] = '\0';
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC branch_callback(
+    __attribute__((unused)) FAPI_CONTEXT        *fapi_context,
+    char                    const  *description,
+    char                    const **branchNames,
+    size_t                          numBranches,
+    size_t                         *selectedBranch,
+    __attribute__((unused)) void   *userData)
+{
+    printf ("Select a branch for %s\n", description);
+    for (size_t i = 0; i < numBranches; i++) {
+        printf ("%4zu %s\n", i + 1, branchNames[i]);
+    }
+
+    while (1) {
+        printf ("Your choice: ");
+        if (scanf ("%zu", selectedBranch) != EOF) {
+            while (getchar () != '\n'); /* Consume all remainign input */
+            if (*selectedBranch > numBranches || *selectedBranch < 1) {
+                fprintf (stderr, "The entered integer must be positive and "\
+                    "less than %zu.\n", numBranches + 1);
+            } else {
+                numBranches--;
+                return TSS2_RC_SUCCESS;
+            }
+        } else {
+            fprintf (stderr, "No number received, but EOF.\n");
+            return TSS2_RC_SUCCESS;
+        }
+    }
+}
+
+static FAPI_CONTEXT* ctx_init(char const * uri) {
+    FAPI_CONTEXT* ret;
+    const unsigned int rval = Fapi_Initialize(&ret, uri);
+    if(rval != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_Initialize", rval);
+        return NULL;
+    }
+    return ret;
+}
+
+/*
+ * This program is a template for TPM2 tools that use the FAPI. It does
+ * nothing more than parsing command line options that allow the caller to
+ * specify which FAPI function to call.
+ */
+int main(int argc, char *argv[]) {
+    tpm2_options *tool_opts = NULL;
+    if (!tss2_tool_onstart (&tool_opts)) {
+        fprintf (stderr,"error retrieving tool options\n");
+        return 1;
+    }
+    int ret = 1;
+    char *password = NULL;
+    FAPI_CONTEXT *fctx = ctx_init (NULL);
+    if (!fctx)
+        goto free_opts;
+
+    TSS2_RC r = Fapi_SetAuthCB (fctx, auth_callback, &password);
+    if (r != TSS2_RC_SUCCESS) {
+        fprintf (stderr, "Fapi_SetAuthCB returned %u\n", r);
+        Fapi_Finalize (&fctx);
+        goto free_opts;
+    }
+    r = Fapi_SetBranchCB (fctx, branch_callback, NULL);
+    if (r != TSS2_RC_SUCCESS) {
+        fprintf (stderr, "Fapi_SetBranchCB returned %u\n", r);
+        Fapi_Finalize (&fctx);
+        goto free_opts;
+    }
+
+    tpm2_option_code rc = tss2_handle_options (argc, argv, &tool_opts, fctx);
+
+    if (rc != tpm2_option_code_continue) {
+        ret = rc == tpm2_option_code_err ? 1 : 0;
+        Fapi_Finalize (&fctx);
+        goto free_opts;
+    }
+
+    /*
+     * Call the specific tool, all tools implement this function instead of
+     * 'main'.
+     * rc 1 = failure
+     * rc 0 = success
+     * rc -1 = show usage
+     */
+    ret = tss2_tool_onrun(fctx);
+    if (ret < 0) {
+        tpm2_print_usage(argv[0], tool_opts);
+        ret = 1;
+    }
+
+    /*
+     * Cleanup contexts & memory allocated for the modified argument vector
+     * passed to execute_tool.
+     */
+    Fapi_Finalize (&fctx);
+free_opts:
+    if (tool_opts)
+        tpm2_options_free (tool_opts);
+    free (password);
+    exit(ret);
+}
+
+int open_write_and_close(const char* path, bool overwrite, const void *output,
+    size_t output_len) {
+    size_t length = output_len ? output_len : strlen (output);
+    if (!path || !strcmp(path, "-")) {
+        if (-1 == write (STDOUT_FILENO, output, length)) {
+            fprintf (stderr, "write(2) to stdout failed: %m\n");
+            return 1;
+        }
+        putchar ('\n');
+        return 0;
+    }
+    if (!overwrite) {
+        struct stat stat_;
+        if (!stat (path, &stat_)) {
+            fprintf (stderr, "File %s already exists, use --force to "\
+                "overwrite it\n", path);
+            return 1;
+        }
+    }
+    int fileno = open (path, O_CREAT | O_WRONLY | O_TRUNC, S_IWUSR | S_IRUSR);
+    if (fileno == -1) {
+        fprintf (stderr, "open(2) %s failed: %m\n", path);
+        return 1;
+    }
+
+    ssize_t bytes_written = write (fileno, output, length);
+    if (bytes_written == -1) {
+        fprintf (stderr, "write(2) %s failed: %m\n", path);
+        return 1;
+    }
+    if (bytes_written - length) {
+        fprintf (stderr, "write(2) could not write the whole file, deleting "\
+            "%s\n", path);
+        unlink (path);
+        close (fileno);
+        return 1;
+    }
+    if (close (fileno)) {
+        fprintf (stderr, "close(2) %s failed: %m\n", path);
+        return 1;
+    }
+    return 0;
+}
+
+int open_read_and_close (const char *path, void **input, size_t *size) {
+    if (!path || !strcmp(path, "-")) {
+        size_t data_consumed = 0, buffer_size = 1024, data_read;
+        *input = malloc (buffer_size + 1);
+        if (!*input) {
+            fprintf (stderr, "malloc(2) failed: %m\n");
+            return 1;
+        }
+        while ((data_read = read (STDIN_FILENO, *input + data_consumed, 1024))){
+            data_consumed += data_read;
+            if (data_read < 1024) /* EOF reached */
+                break;
+            buffer_size += 1024;
+            *input = realloc (*input, buffer_size + 1);
+            if (!*input) {
+                fprintf (stderr, "realloc(3) failed: %m\n");
+                return 1;
+            }
+        }
+        if (size)
+            *size = data_consumed;
+        ((char*)(*input))[data_consumed] = 0;
+        return 0;
+    }
+    int fileno = open (path, O_RDONLY);
+    if (fileno == -1) {
+        fprintf (stderr, "Opening %s failed: %m\n", path);
+        return 1;
+    }
+
+    struct stat stat_;
+    fstat (fileno, &stat_);
+    if (size)
+        *size = stat_.st_size;
+    *input = malloc (stat_.st_size + 1);
+    if (!*input) {
+        fprintf (stderr, "malloc(2) failed: %m\n");
+        return 1;
+    }
+    if (-1 == read (fileno, *input, stat_.st_size)) {
+        fprintf (stderr, "read(2) %s failed with: %m\n", path);
+        free (*input);
+        return 1;
+    }
+    ((char*)(*input))[stat_.st_size] = '\0';
+    if (close (fileno)) {
+        fprintf (stderr, "Error close(2) %s: %m\n", path);
+        free (*input);
+        return 1;
+    }
+    return 0;
+}
+
+char* ask_for_password() {
+    char *pw1, *pw2;
+    if (auth_callback (NULL, "Password", &pw1, NULL))
+        return NULL;
+
+    if (auth_callback (NULL, "Retype password", &pw2, NULL)) {
+        free (pw1);
+        return NULL;
+    }
+    if (strcmp (pw1, pw2)) {
+        fprintf (stderr, "Passwords do not match.\n");
+        free (pw1);
+        free (pw2);
+        return NULL;
+    }
+    free (pw1);
+    return pw2;
+}
+
+void LOG_PERR(const char *func, TSS2_RC rc) {
+    fprintf (stderr, "%s(0x%X) - %s\n", func, rc, Tss2_RC_Decode(rc));
+}
+
+void LOG_ERR(const char *format, ...) {
+   va_list arg;
+   va_start (arg, format);
+   vfprintf (stderr, format, arg);
+   va_end (arg);
+}

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -265,7 +265,7 @@ TSS2_RC branch_callback(
 static FAPI_CONTEXT* ctx_init(char const * uri) {
     FAPI_CONTEXT* ret;
     const unsigned int rval = Fapi_Initialize(&ret, uri);
-    if(rval != TSS2_RC_SUCCESS){
+    if (rval != TSS2_RC_SUCCESS){
         LOG_PERR("Fapi_Initialize", rval);
         return NULL;
     }

--- a/tools/fapi/tss2_template.h
+++ b/tools/fapi/tss2_template.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef TSS2_TEMPLATE_H
+#define TSS2_TEMPLATE_H
+#include <stdbool.h>
+#include <tss2/tss2_fapi.h>
+
+#include "lib/tpm2_options.h"
+#include "lib/tpm2_util.h"
+
+#define Fapi_Free(x) free(x)
+
+/**
+ * An optional interface for tools to specify what options they support.
+ * They are concatenated with main's options and passed to getopt_long.
+ * @param opts
+ *  The callee can choose to set *opts to a tpm_options pointer allocated
+ *  via tpm2_options_new(). Setting *opts to NULL is not an error, and
+ *  Indicates that no options are specified by the tool.
+ *
+ * @return
+ *  True on success, false on error.
+ */
+bool tss2_tool_onstart(tpm2_options **opts) __attribute__((visibility("hidden")));
+
+/**
+ * This is the main interface for tools, after tcti and fapi initialization
+ * is performed.
+ * @param fctx
+ *  The fapi api context.
+ * @return
+ *  0 on success
+ *  1 on failure
+ * -1 to show usage
+ */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) __attribute__((weak, visibility("hidden")));
+
+/**
+ * Called when the tool is exiting, useful for cleanup.
+ */
+void tss2_tool_onexit(void) __attribute__((weak, visibility("hidden")));
+
+TSS2_RC policy_auth_callback(FAPI_CONTEXT*, char const*, char**, void*);
+int open_write_and_close(const char *path, bool overwrite, const void* output, size_t output_len);
+int open_read_and_close(const char *path, void **input, size_t *size);
+char* ask_for_password();
+void LOG_PERR(const char *func, TSS2_RC rc);
+void LOG_ERR(const char *format, ...);
+#endif /* TSS2_TEMPLATE_H */

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -10,7 +10,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed command line parameters */
 static struct cxt {
-    char const *keyPath;
+    char const *path;
     char const *data;
     bool        overwrite;
 } ctx;
@@ -22,9 +22,9 @@ static bool on_option(char key, char *value) {
         ctx.overwrite = true;
         break;
     case 'p':
-        ctx.keyPath = value;
+        ctx.path = value;
         break;
-    case 'd':
+    case 'o':
         ctx.data = value;
         break;
     }
@@ -35,29 +35,29 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path",    required_argument, NULL, 'p'},
-        {"data",    required_argument, NULL, 'd'},
+        {"data",    required_argument, NULL, 'o'},
         {"force",   no_argument, NULL, 'f'}
     };
-    return (*opts = tpm2_options_new ("p:d:f", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:o:f", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
-    if (!ctx.keyPath) {
-        fprintf (stderr, "path to the sealed data missing, use --path=\n");
+    if (!ctx.path) {
+        fprintf (stderr, "path to the sealed data missing, use --path\n");
         return -1;
     }
     if (!ctx.data) {
-        fprintf (stderr, "path to decrypted data missing, use --data=\n");
+        fprintf (stderr, "path to decrypted data missing, use --data\n");
         return -1;
     }
 
     /* Execute FAPI command with passed arguments */
     uint8_t *data;
     size_t size;
-    TSS2_RC r = Fapi_Unseal (fctx, ctx.keyPath, &data, &size);
+    TSS2_RC r = Fapi_Unseal (fctx, ctx.path, &data, &size);
     if (r != TSS2_RC_SUCCESS){
         LOG_PERR ("Fapi_Unseal", r);
         return 1;

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *keyPath;
+    char const *data;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.keyPath = value;
+        break;
+    case 'd':
+        ctx.data = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path",    required_argument, NULL, 'p'},
+        {"data",    required_argument, NULL, 'd'},
+        {"force",   no_argument, NULL, 'f'}
+    };
+    return (*opts = tpm2_options_new ("p:d:f", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.keyPath) {
+        fprintf (stderr, "path to the sealed data missing, use --path=\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "path to decrypted data missing, use --data=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *data;
+    size_t size;
+    TSS2_RC r = Fapi_Unseal (fctx, ctx.keyPath, &data, &size);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_Unseal", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.data, ctx.overwrite, data, size);
+    if (r){
+        LOG_PERR ("open_write_and_close data", r);
+        Fapi_Free (data);
+        return 1;
+    }
+
+    Fapi_Free (data);
+    return 0;
+}

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *path;
+    char const *data;
+    bool        overwrite;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    case 'o':
+        ctx.data = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path",    required_argument, NULL, 'p'},
+        {"data",    required_argument, NULL, 'o'},
+        {"force",   no_argument, NULL, 'f'}
+    };
+    return (*opts = tpm2_options_new ("p:o:f", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path to the sealed data missing, use --path\n");
+        return -1;
+    }
+    if (!ctx.data) {
+        fprintf (stderr, "path to decrypted data missing, use --data\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    uint8_t *data;
+    size_t size;
+    TSS2_RC r = Fapi_Unseal (fctx, ctx.path, &data, &size);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_Unseal", r);
+        return 1;
+    }
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.data, ctx.overwrite, data, size);
+    if (r){
+        LOG_PERR ("open_write_and_close data", r);
+        Fapi_Free (data);
+        return 1;
+    }
+
+    Fapi_Free (data);
+    return 0;
+}

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -113,7 +113,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         free (signature);
         return -1;
     }
-    if(pcrEventLog){
+    if (pcrEventLog){
         r = open_read_and_close (ctx.pcrEventLog, (void**)&pcrEventLog, NULL);
         if (r) {
             LOG_PERR ("open_read_and_close pcrEventLog", r);

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *publicKeyPath;
+    char const *qualifyingData;
+    char const *quoteInfo;
+    char const *signature;
+    char const *pcrLog;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'Q':
+        ctx.qualifyingData = value;
+        break;
+    case 'l':
+        ctx.pcrLog = value;
+        break;
+    case 'q':
+        ctx.quoteInfo = value;
+        break;
+    case 'k':
+        ctx.publicKeyPath = value;
+        break;
+    case 'i':
+        ctx.signature = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"publicKeyPath",   required_argument, NULL, 'k'},
+        {"qualifyingData",  required_argument, NULL, 'Q'},
+        {"quoteInfo",       required_argument, NULL, 'q'},
+        {"signature",       required_argument, NULL, 'i'},
+        {"pcrLog",          optional_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("k:Q:q:i:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.qualifyingData) {
+        fprintf (stderr, "qualifying data parameter not provided, use "\
+            "--qualifyingData\n");
+        return -1;
+    }
+    if (!ctx.quoteInfo) {
+        fprintf (stderr, "quote info parameter not provided, use "\
+            "--quoteInfo\n");
+        return -1;
+    }
+    if (!ctx.publicKeyPath) {
+        fprintf (stderr, "publicKeyPath parameter not provided, use "\
+            "--publicKeyPath\n");
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "signature parameter not provided, use"\
+            " --signature\n");
+        return -1;
+    }
+    if (!ctx.pcrLog) {
+        fprintf (stderr, "pcrLog parameter not provided, use"\
+            " --pcrLog\n");
+        return -1;
+    }
+    if (!strcmp (ctx.signature, "-") + !strcmp(ctx.qualifyingData, "-") +
+        !strcmp(ctx.quoteInfo, "-") + !strcmp(ctx.pcrLog, "-") > 1) {
+            fprintf (stderr, "At most one of --signature, "\
+                "--qualifyingData, --quoteInfo and --pcrLog can "\
+                "be '-' (standard output)\n");
+            return -1;
+    }
+
+    /* Read qualifyingData, signature, quoteInfo and pcrLog from file */
+    uint8_t *qualifyingData;
+    size_t qualifyingDataSize;
+    TSS2_RC r = open_read_and_close (ctx.qualifyingData,
+        (void**)&qualifyingData, &qualifyingDataSize);
+    if (r){
+        LOG_PERR ("open_read_and_close qualifyingData", r);
+        return -1;
+    }
+    uint8_t *signature;
+    size_t signatureSize;
+    r = open_read_and_close (ctx.signature, (void**)&signature, &signatureSize);
+    if (r) {
+        LOG_PERR ("open_read_and_close signature", r);
+        free (qualifyingData);
+        return -1;
+    }
+    char *quoteInfo, *pcrLog = NULL;
+    r = open_read_and_close (ctx.quoteInfo, (void**)&quoteInfo, NULL);
+    if (r) {
+        LOG_PERR ("open_read_and_close quoteInfo", r);
+        free (qualifyingData);
+        free (signature);
+        return -1;
+    }
+    if (pcrLog){
+        r = open_read_and_close (ctx.pcrLog, (void**)&pcrLog, NULL);
+        if (r) {
+            LOG_PERR ("open_read_and_close pcrLog", r);
+            free (qualifyingData);
+            free (signature);
+            free (quoteInfo);
+            return -1;
+        }
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_VerifyQuote (fctx, ctx.publicKeyPath, qualifyingData,
+        qualifyingDataSize, quoteInfo, signature, signatureSize,
+        pcrLog);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_VerifyQuote", r);
+        return 1;
+    }
+
+    free (qualifyingData);
+    free (signature);
+    free (quoteInfo);
+    free (pcrLog);
+
+    return 0;
+}

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char *publicKeyPath;
+    char const *qualifyingData;
+    char const *quoteInfo;
+    char const *signature;
+    char const *pcrEventLog;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'q':
+        ctx.qualifyingData = value;
+        break;
+    case 'l':
+        ctx.pcrEventLog = value;
+        break;
+    case 'i':
+        ctx.quoteInfo = value;
+        break;
+    case 'p':
+        ctx.publicKeyPath = value;
+        break;
+    case 's':
+        ctx.signature = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"publicKeyPath",   required_argument, NULL, 'p'},
+        {"qualifyingData",  required_argument, NULL, 'q'},
+        {"quoteInfo",       required_argument, NULL, 'i'},
+        {"signature",       required_argument, NULL, 's'},
+        {"pcrLog",          optional_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("q:l:i:p:s:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.qualifyingData) {
+        fprintf (stderr, "qualifying data parameter not provided, use "\
+            "--qualifyingData=\n");
+        return -1;
+    }
+    if (!ctx.quoteInfo) {
+        fprintf (stderr, "quote info parameter not provided, use "\
+            "--quoteInfo=\n");
+        return -1;
+    }
+    if (!ctx.publicKeyPath) {
+        fprintf (stderr, "publicKeyPath parameter not provided, use "\
+            "--publicKeyPath=\n");
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "signature parameter not provided, use"\
+            " --signature=\n");
+        return -1;
+    }
+    if (!ctx.pcrEventLog) {
+        fprintf (stderr, "pcrLog parameter not provided, use"\
+            " --pcrLog=\n");
+        return -1;
+    }
+    if (!strcmp (ctx.signature, "-") + !strcmp(ctx.qualifyingData, "-") +
+        !strcmp(ctx.quoteInfo, "-") + !strcmp(ctx.pcrEventLog, "-") > 1) {
+            fprintf (stderr, "At most one of --signature, "\
+                "--qualifyingData, --quoteInfo and --pcrLog can "\
+                "be '-' (standard output)\n");
+            return -1;
+    }
+
+    /* Read qualifyingData, signature, quoteInfo and pcrEventLog from file */
+    uint8_t *qualifyingData;
+    size_t qualifyingDataSize;
+    TSS2_RC r = open_read_and_close (ctx.qualifyingData,
+        (void**)&qualifyingData, &qualifyingDataSize);
+    if (r){
+        LOG_PERR ("open_read_and_close qualifyingData", r);
+        return -1;
+    }
+    uint8_t *signature;
+    size_t signatureSize;
+    r = open_read_and_close (ctx.signature, (void**)&signature, &signatureSize);
+    if (r) {
+        LOG_PERR ("open_read_and_close signature", r);
+        free (qualifyingData);
+        return -1;
+    }
+    char *quoteInfo, *pcrEventLog = NULL;
+    r = open_read_and_close (ctx.quoteInfo, (void**)&quoteInfo, NULL);
+    if (r) {
+        LOG_PERR ("open_read_and_close quoteInfo", r);
+        free (qualifyingData);
+        free (signature);
+        return -1;
+    }
+    if(pcrEventLog){
+        r = open_read_and_close (ctx.pcrEventLog, (void**)&pcrEventLog, NULL);
+        if (r) {
+            LOG_PERR ("open_read_and_close pcrEventLog", r);
+            free (qualifyingData);
+            free (signature);
+            free (quoteInfo);
+            return -1;
+        }
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_VerifyQuote (fctx, ctx.publicKeyPath, qualifyingData,
+        qualifyingDataSize, quoteInfo, signature, signatureSize,
+        pcrEventLog);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_VerifyQuote", r);
+        return 1;
+    }
+
+    free (qualifyingData);
+    free (signature);
+    free (quoteInfo);
+    free (pcrEventLog);
+
+    return 0;
+}

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *digest;
+    char const *publicKeyPath;
+    char const *signature;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'd':
+        ctx.digest = value;
+        break;
+    case 'k':
+        ctx.publicKeyPath = value;
+        break;
+    case 's':
+        ctx.signature = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'k'},
+        {"digest",      required_argument, NULL, 'd'},
+        {"signature",   required_argument, NULL, 's'}
+    };
+    return (*opts = tpm2_options_new ("d:k:s:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.publicKeyPath) {
+        fprintf (stderr, "public key path parameter not provided, use " \
+            "--keyPath=\n");
+        return -1;
+    }
+    if (!ctx.digest) {
+        fprintf (stderr, "digest parameter not provided, use --digest=\n");
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "signature parameter not provided, use "\
+            "--signature=\n");
+        return -1;
+    }
+    if (!strcmp ("-", ctx.signature)  && !strcmp("-", ctx.digest)) {
+        fprintf (stderr, "At most one of --signature= and --digest= can be '-'"\
+            " (standard input)\n");
+        return -1;
+    }
+
+    /* Read data needed for signature verification */
+    uint8_t *digest, *signature;
+    size_t digestSize, signatureSize;
+    TSS2_RC r = open_read_and_close (ctx.digest, (void**)&digest, &digestSize);
+    if (r){
+        LOG_PERR("open_read_and_close digest", r);
+        return 1;
+    }
+    r = open_read_and_close (ctx.signature, (void**)&signature, &signatureSize);
+    if (r) {
+        LOG_PERR("open_read_and_close signature", r);
+        free (digest);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_VerifySignature (fctx, ctx.publicKeyPath,
+        digest, digestSize, signature, signatureSize);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_Key_VerifySignature", r);
+        return 1;
+    }
+    free (digest);
+    free (signature);
+    return 0;
+}

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *digest;
+    char const *publicKeyPath;
+    char const *signature;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'd':
+        ctx.digest = value;
+        break;
+    case 'p':
+        ctx.publicKeyPath = value;
+        break;
+    case 'i':
+        ctx.signature = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"keyPath",     required_argument, NULL, 'p'},
+        {"digest",      required_argument, NULL, 'd'},
+        {"signature",   required_argument, NULL, 'i'}
+    };
+    return (*opts = tpm2_options_new ("d:p:i:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.publicKeyPath) {
+        fprintf (stderr, "public key path parameter not provided, use " \
+            "--keyPath\n");
+        return -1;
+    }
+    if (!ctx.digest) {
+        fprintf (stderr, "digest parameter not provided, use --digest\n");
+        return -1;
+    }
+    if (!ctx.signature) {
+        fprintf (stderr, "signature parameter not provided, use "\
+            "--signature\n");
+        return -1;
+    }
+    if (!strcmp ("-", ctx.signature)  && !strcmp("-", ctx.digest)) {
+        fprintf (stderr, "At most one of --signature and --digest can be '-'"\
+            " (standard input)\n");
+        return -1;
+    }
+
+    /* Read data needed for signature verification */
+    uint8_t *digest, *signature;
+    size_t digestSize, signatureSize;
+    TSS2_RC r = open_read_and_close (ctx.digest, (void**)&digest, &digestSize);
+    if (r){
+        LOG_PERR("open_read_and_close digest", r);
+        return 1;
+    }
+    r = open_read_and_close (ctx.signature, (void**)&signature, &signatureSize);
+    if (r) {
+        LOG_PERR("open_read_and_close signature", r);
+        free (digest);
+        return 1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    r = Fapi_VerifySignature (fctx, ctx.publicKeyPath,
+        digest, digestSize, signature, signatureSize);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR("Fapi_Key_VerifySignature", r);
+        return 1;
+    }
+    free (digest);
+    free (signature);
+    return 0;
+}

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -22,10 +22,10 @@ static bool on_option(char key, char *value) {
     case 'd':
         ctx.digest = value;
         break;
-    case 'k':
+    case 'p':
         ctx.publicKeyPath = value;
         break;
-    case 's':
+    case 'i':
         ctx.signature = value;
         break;
     }
@@ -35,11 +35,11 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"keyPath",     required_argument, NULL, 'k'},
+        {"keyPath",     required_argument, NULL, 'p'},
         {"digest",      required_argument, NULL, 'd'},
-        {"signature",   required_argument, NULL, 's'}
+        {"signature",   required_argument, NULL, 'i'}
     };
-    return (*opts = tpm2_options_new ("d:k:s:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("d:p:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -48,20 +48,20 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.publicKeyPath) {
         fprintf (stderr, "public key path parameter not provided, use " \
-            "--keyPath=\n");
+            "--keyPath\n");
         return -1;
     }
     if (!ctx.digest) {
-        fprintf (stderr, "digest parameter not provided, use --digest=\n");
+        fprintf (stderr, "digest parameter not provided, use --digest\n");
         return -1;
     }
     if (!ctx.signature) {
         fprintf (stderr, "signature parameter not provided, use "\
-            "--signature=\n");
+            "--signature\n");
         return -1;
     }
     if (!strcmp ("-", ctx.signature)  && !strcmp("-", ctx.digest)) {
-        fprintf (stderr, "At most one of --signature= and --digest= can be '-'"\
+        fprintf (stderr, "At most one of --signature and --digest can be '-'"\
             " (standard input)\n");
         return -1;
     }

--- a/tools/fapi/tss2_writeauthorizenv.c
+++ b/tools/fapi/tss2_writeauthorizenv.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *nvPath;
+    char const *policyPath;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'p':
+        ctx.nvPath = value;
+        break;
+    case 'P':
+        ctx.policyPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"nvPath"  , required_argument, NULL, 'p'},
+        {"policyPath"  , required_argument, NULL, 'P'}
+    };
+    return (*opts = tpm2_options_new ("p:P:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
+        return -1;
+    }
+    if (!ctx.policyPath) {
+        fprintf (stderr, "No policy path provided, use --policyPath\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_WriteAuthorizeNv(fctx, ctx.nvPath, ctx.policyPath);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_WriteAuthorizeNv", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/fapi/tss2_writeauthorizenv.c
+++ b/tools/fapi/tss2_writeauthorizenv.c
@@ -18,10 +18,10 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
-    case 'n':
+    case 'p':
         ctx.nvPath = value;
         break;
-    case 'l':
+    case 'P':
         ctx.policyPath = value;
         break;
     }
@@ -31,10 +31,10 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
-        {"nvPath"  , required_argument, NULL, 'n'},
-        {"policyPath"  , required_argument, NULL, 'l'}
+        {"nvPath"  , required_argument, NULL, 'p'},
+        {"policyPath"  , required_argument, NULL, 'P'}
     };
-    return (*opts = tpm2_options_new ("n:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("p:P:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -42,11 +42,11 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
-        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        fprintf (stderr, "No NV path provided, use --nvPath\n");
         return -1;
     }
     if (!ctx.policyPath) {
-        fprintf (stderr, "No policy path provided, use --policyPath=\n");
+        fprintf (stderr, "No policy path provided, use --policyPath\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_writeauthorizenv.c
+++ b/tools/fapi/tss2_writeauthorizenv.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tools/fapi/tss2_template.h"
+
+/* needed by tpm2_util and tpm2_option functions */
+bool output_enabled = false;
+
+/* Context struct used to store passed command line parameters */
+static struct cxt {
+    char const *nvPath;
+    char const *policyPath;
+} ctx;
+
+/* Parse command line parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'n':
+        ctx.nvPath = value;
+        break;
+    case 'l':
+        ctx.policyPath = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible command line parameters */
+bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"nvPath"  , required_argument, NULL, 'n'},
+        {"policyPath"  , required_argument, NULL, 'l'}
+    };
+    return (*opts = tpm2_options_new ("n:l:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.nvPath) {
+        fprintf (stderr, "No NV path provided, use --nvPath=\n");
+        return -1;
+    }
+    if (!ctx.policyPath) {
+        fprintf (stderr, "No policy path provided, use --policyPath=\n");
+        return -1;
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_WriteAuthorizeNv(fctx, ctx.nvPath, ctx.policyPath);
+    if (r != TSS2_RC_SUCCESS){
+        LOG_PERR ("Fapi_WriteAuthorizeNv", r);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/misc/tpm2_eventlog.c
+++ b/tools/misc/tpm2_eventlog.c
@@ -42,7 +42,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     bool ret = false;
     UINT8 *eventlog;
-    size_t size = 0;
+    unsigned long size = 0;
 
     if (filename == NULL) {
         LOG_ERR("Missing required positional parameter, try -h / --help");
@@ -55,7 +55,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     eventlog = calloc(1, size);
     if (eventlog == NULL){
-        LOG_ERR("failed to allocate %zd bytes: %s", size, strerror(errno));
+        LOG_ERR("failed to allocate %lu bytes: %s", size, strerror(errno));
         return tool_rc_general_error;
     }
 

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -32,6 +32,7 @@ struct tpm_getekcertificate_ctx {
 
 static tpm_getekcertificate_ctx ctx = {
     .is_tpm2_device_active = true,
+    .ek_server_addr = "https://ekop.intel.com/ekcertservice/",
 };
 
 static unsigned char *hash_ek_public(void) {

--- a/tools/tpm2_hierarchycontrol.c
+++ b/tools/tpm2_hierarchycontrol.c
@@ -32,8 +32,14 @@ static tool_rc hierarchycontrol(ESYS_CONTEXT *ectx) {
         ctx.enable == TPM2_RH_ENDORSEMENT ? "ehEnable" : "phEnableNV",
         ctx.state ? "SET" : "CLEAR");
 
-    return tpm2_hierarchycontrol(ectx, &ctx.auth_hierarchy.object, ctx.enable,
-            ctx.state);
+    tool_rc rc = tpm2_hierarchycontrol(ectx, &ctx.auth_hierarchy.object,
+        ctx.enable, ctx.state);
+
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed hierarchycontrol operation.");
+    }
+
+    return rc;
 }
 
 bool on_arg(int argc, char **argv) {

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -65,7 +65,7 @@ static tool_rc nv_space_define(ESYS_CONTEXT *ectx) {
     tool_rc rc = tpm2_nv_definespace(ectx, &ctx.auth_hierarchy.object,
             &ctx.nv_auth, &public_info);
     if (rc != tool_rc_success) {
-        LOG_INFO("Success to define NV area at index 0x%x.", ctx.nv_index);
+        LOG_ERR("Failed to create NV index 0x%x.", ctx.nv_index);
         return rc;
     }
 

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -47,16 +47,32 @@ static bool on_option(char key, char *value) {
     return result;
 }
 
+static bool on_arg(int argc, char **argv) {
+
+    if (argc > 1) {
+        LOG_ERR("specify single argument for policy list.");
+        return false;
+    }
+
+    ctx.policy_list = calloc(1, sizeof(TPML_DIGEST));
+    bool result = tpm2_policy_parse_policy_list(argv[0], ctx.policy_list);
+    if (!result) {
+        return false;
+    }
+    return true;
+}
+
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
         { "policy",                 required_argument, NULL, 'L' },
         { "session",                required_argument, NULL, 'S' },
+        //Option retained for backwards compatibility - See issue#1894
         { "policy-list",            required_argument, NULL, 'l' },
     };
 
     *opts = tpm2_options_new("L:S:l:", ARRAY_LEN(topts), topts, on_option,
-    NULL, 0);
+        on_arg, 0);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
These commits fix two issues:
* FAPI: Fix integation test "fapi-pcr-extend-read": In the current TSS version, the log file needs to be JSON encoded.
* tpm2_eventlog: Fix type of a called function's parameter: Fixed an error where tpm2_eventlog called a function with the wrong type as parameter.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>